### PR TITLE
Fix major Java version detection

### DIFF
--- a/jaxb-ri/bundles/ri/src/main/resources/bin/schemagen.sh
+++ b/jaxb-ri/bundles/ri/src/main/resources/bin/schemagen.sh
@@ -86,7 +86,7 @@ then
     JAXB_HOME="`cygpath -w "$JAXB_HOME"`"
 fi
 
-JAVA_VERSION=`${JAVA} -version 2>&1 | head -n 1 | cut -d'"' -f2 | sed -E 's/^(1\.)?([0-9]+).+$/\2/'`
+JAVA_VERSION=`${JAVA} -version 2>&1 | head -n 1 | cut -d'"' -f2 | sed -E 's/^(1\.)?([0-9]+)(.+)?$/\2/'`
 echo "Java major version: ${JAVA_VERSION}"
 
 # Check if supports module path

--- a/jaxb-ri/bundles/ri/src/main/resources/bin/xjc.sh
+++ b/jaxb-ri/bundles/ri/src/main/resources/bin/xjc.sh
@@ -71,7 +71,7 @@ ${JAXB_HOME}/mod/javax.activation.jar:\
 ${JAXB_HOME}/mod/relaxng-datatype.jar
 
 
-JAVA_VERSION=`${JAVA} -version 2>&1 | head -n 1 | cut -d'"' -f2 | sed -E 's/^(1\.)?([0-9]+).+$/\2/'`
+JAVA_VERSION=`${JAVA} -version 2>&1 | head -n 1 | cut -d'"' -f2 | sed -E 's/^(1\.)?([0-9]+)(.+)?$/\2/'`
 echo "Java major version: ${JAVA_VERSION}"
 
 # Check if supports module path


### PR DESCRIPTION
Detect "11" as 11 even without minor or dotted version notation by a
non-greedy match after the major version.