### PR TITLE
Drop <p> tag from generated JavaDoc

### DIFF
--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/SimpleTypeBuilder.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/SimpleTypeBuilder.java
@@ -551,7 +551,7 @@ public final class SimpleTypeBuilder extends BindingComponent {
             else                javadoc = "";
 
             javadoc += Messages.format( Messages.JAVADOC_HEADING, type.getName() )
-                +"\n<p>\n<pre>\n"+out.getBuffer()+"</pre>";
+                +"\n<pre>\n"+out.getBuffer()+"</pre>";
 
         }
 


### PR DESCRIPTION
This tag produces a warning when compiling with `-Xdoclint:html` and does not
affect the final rendering.

(This is a re-submission of javaee/jaxb-v2#1141, which is itself a re-submission of a PR against the now-deleted `gf-metro/jaxb` repository.)