### PR TITLE
Add missing .java resource files to jaxb-xjc.jar.

### DIFF
--- a/jaxb-ri/xjc/pom.xml
+++ b/jaxb-ri/xjc/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -263,6 +263,30 @@
                         <additionalJOption>com.sun.tools.xjc=resolver</additionalJOption>
                     </additionalJOptions>
                 </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/classes/com/sun/tools/xjc/runtime</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/java/com/sun/tools/xjc/runtime</directory>
+                                    <filtering>false</filtering>
+                                    <excludes>
+                                        <exclude>package-info.java</exclude>
+                                    </excludes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Adds back generation of src/main/java/com/sun/tools/xjc/runtime resources.
Fixes #1287

Signed-off-by: Roman Grigoriadi <roman.grigoriadi@oracle.com>