### PR TITLE
Ignore Eclipse project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 target/
+**/.settings
+**/.classpath
+**/.project


### PR DESCRIPTION
Eclipse project files and directories (`.settings`, `.project`, `.classpath`) should not be committed and therefore should be added to `.gitignore`.