### PR TITLE
Changing 'jakarta.activation.jar' to 'jakarta.activation-api.jar' in …

### DIFF
--- a/jaxb-ri/bundles/ri/src/main/resources/bin/schemagen.bat
+++ b/jaxb-ri/bundles/ri/src/main/resources/bin/schemagen.bat
@@ -31,7 +31,7 @@ echo JAXB_HOME must be set before running this script
 goto END
 
 :SETCLASSPATH
-set JAXB_PATH=%JAXB_HOME%/mod/jakarta.xml.bind-api.jar;%JAXB_HOME%/mod/jaxb-jxc.jar;%JAXB_HOME%/mod/jaxb-xjc.jar;%JAXB_HOME%/mod/jaxb-runtime.jar;%JAXB_HOME%/mod/stax-ex.jar;%JAXB_HOME%/mod/istack-commons-runtime.jar;%JAXB_HOME%/mod/istack-commons-tools.jar;%JAXB_HOME%/mod/FastInfoset.jar;%JAXB_HOME%/mod/dtd-parser.jar;%JAXB_HOME%/mod/rngom.jar;%JAXB_HOME%/mod/codemodel.jar;%JAXB_HOME%/mod/xsom.jar;%JAXB_HOME%/mod/txw2.jar;%JAXB_HOME%/mod/relaxng-datatype.jar;%JAXB_HOME%/mod/jakarta.activation.jar
+set JAXB_PATH=%JAXB_HOME%/mod/jakarta.xml.bind-api.jar;%JAXB_HOME%/mod/jaxb-jxc.jar;%JAXB_HOME%/mod/jaxb-xjc.jar;%JAXB_HOME%/mod/jaxb-runtime.jar;%JAXB_HOME%/mod/stax-ex.jar;%JAXB_HOME%/mod/istack-commons-runtime.jar;%JAXB_HOME%/mod/istack-commons-tools.jar;%JAXB_HOME%/mod/FastInfoset.jar;%JAXB_HOME%/mod/dtd-parser.jar;%JAXB_HOME%/mod/rngom.jar;%JAXB_HOME%/mod/codemodel.jar;%JAXB_HOME%/mod/xsom.jar;%JAXB_HOME%/mod/txw2.jar;%JAXB_HOME%/mod/relaxng-datatype.jar;%JAXB_HOME%/mod/jakarta.activation-api.jar
 
 if "%CLASSPATH%" == "" goto NOUSERCLASSPATH
 set LOCALCLASSPATH=%JAXB_PATH%;%CLASSPATH%

--- a/jaxb-ri/bundles/ri/src/main/resources/bin/schemagen.sh
+++ b/jaxb-ri/bundles/ri/src/main/resources/bin/schemagen.sh
@@ -57,7 +57,7 @@ ${JAXB_HOME}/mod/codemodel.jar:\
 ${JAXB_HOME}/mod/xsom.jar:\
 ${JAXB_HOME}/mod/txw2.jar:\
 ${JAXB_HOME}/mod/relaxng-datatype.jar:\
-${JAXB_HOME}/mod/jakarta.activation.jar
+${JAXB_HOME}/mod/jakarta.activation-api.jar
 
 
 # add the api jar file

--- a/jaxb-ri/bundles/ri/src/main/resources/bin/xjc.bat
+++ b/jaxb-ri/bundles/ri/src/main/resources/bin/xjc.bat
@@ -42,7 +42,7 @@ goto LAUNCHXJC
 
 :LAUNCHXJC
 rem JXC module path
-set JAXB_PATH=%JAXB_HOME%/mod/jaxb-xjc.jar;%JAXB_HOME%/mod/jakarta.xml.bind-api.jar;%JAXB_HOME%/mod/codemodel.jar;%JAXB_HOME%/mod/jaxb-runtime.jar;%JAXB_HOME%/mod/istack-commons-runtime.jar;%JAXB_HOME%/mod/istack-commons-tools.jar;%JAXB_HOME%/mod/rngom.jar;%JAXB_HOME%/mod/xsom.jar;%JAXB_HOME%/mod/dtd-parser.jar;%JAXB_HOME%/mod/txw2.jar;%JAXB_HOME%/mod/stax-ex.jar;%JAXB_HOME%/mod/FastInfoset.jar;%JAXB_HOME%/mod/jakarta.activation.jar;%JAXB_HOME%/mod/relaxng-datatype.jar
+set JAXB_PATH=%JAXB_HOME%/mod/jaxb-xjc.jar;%JAXB_HOME%/mod/jakarta.xml.bind-api.jar;%JAXB_HOME%/mod/codemodel.jar;%JAXB_HOME%/mod/jaxb-runtime.jar;%JAXB_HOME%/mod/istack-commons-runtime.jar;%JAXB_HOME%/mod/istack-commons-tools.jar;%JAXB_HOME%/mod/rngom.jar;%JAXB_HOME%/mod/xsom.jar;%JAXB_HOME%/mod/dtd-parser.jar;%JAXB_HOME%/mod/txw2.jar;%JAXB_HOME%/mod/stax-ex.jar;%JAXB_HOME%/mod/FastInfoset.jar;%JAXB_HOME%/mod/jakarta.activation-api.jar;%JAXB_HOME%/mod/relaxng-datatype.jar
 
 rem Set Java Version
 for /f "tokens=3" %%i in ('java -version 2^>^&1 ^| %SystemRoot%\system32\find.exe "version"') do (

--- a/jaxb-ri/bundles/ri/src/main/resources/bin/xjc.sh
+++ b/jaxb-ri/bundles/ri/src/main/resources/bin/xjc.sh
@@ -67,7 +67,7 @@ ${JAXB_HOME}/mod/dtd-parser.jar:\
 ${JAXB_HOME}/mod/txw2.jar:\
 ${JAXB_HOME}/mod/stax-ex.jar:\
 ${JAXB_HOME}/mod/FastInfoset.jar:\
-${JAXB_HOME}/mod/jakarta.activation.jar:\
+${JAXB_HOME}/mod/jakarta.activation-api.jar:\
 ${JAXB_HOME}/mod/relaxng-datatype.jar
 
 


### PR DESCRIPTION
…start scripts to run with JDK 12

There is a small typo in the naming of the jakarat.activion JAR in all batch files, see
https://mvnrepository.com/artifact/jakarta.activation/jakarta.activation-api/1.2.1