### PR TITLE
Fix file descriptor leak in the plugin for episode generation

### DIFF
--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/addon/episode/PluginImpl.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/addon/episode/PluginImpl.java
@@ -87,6 +87,7 @@ public class PluginImpl extends Plugin {
      * and generate them in an episode file.
      */
     public boolean run(Outline model, Options opt, ErrorHandler errorHandler) throws SAXException {
+        OutputStream episodeFileOutputStream = null;
         try {
             // reorganize qualifying components by their namespaces to
             // generate the list nicely
@@ -136,8 +137,8 @@ public class PluginImpl extends Plugin {
                     hasComponentInNoNamespace = true;
             }
 
-            OutputStream os = new FileOutputStream(episodeFile);
-            Bindings bindings = TXW.create(Bindings.class, new StreamSerializer(os, "UTF-8"));
+            episodeFileOutputStream = new FileOutputStream(episodeFile);
+            Bindings bindings = TXW.create(Bindings.class, new StreamSerializer(episodeFileOutputStream, "UTF-8"));
             if(hasComponentInNoNamespace) // otherwise jaxb binding NS should be the default namespace
                 bindings._namespace(Const.JAXB_NSURI,"jaxb");
             else
@@ -176,6 +177,14 @@ public class PluginImpl extends Plugin {
         } catch (IOException e) {
             errorHandler.error(new SAXParseException("Failed to write to "+episodeFile,null,e));
             return false;
+        } finally {
+            if (episodeFileOutputStream != null) {
+                try {
+                    episodeFileOutputStream.close();
+                } catch (IOException e) {
+                    errorHandler.error(new SAXParseException("Failed to close file handle for "+episodeFile,null,e));
+                }
+            }
         }
     }
 


### PR DESCRIPTION
As it is now, the plugin opens an OutputStream to the episode file and flushes it after the document has successfully been constructed. However, it doesn't close the stream explicitly and instead relies on the GC collecting the stream object, which in turn closes it through the finalize method.

Until the GC decides to collect the object (which it may chose to never do), the plugin will hold a file descriptor open. On Windows, this locks the file and prevents any further actions on it, like rewriting it by re-running XJC.

This is not a problem when XJC is run in a short-lived JVM process, such as when run from the command line or through the Maven plugin. But on long-lived processes, such as through a Gradle daemon, it will lock the file and prevent it to run again.

This PR ensures that the OutputStream is always closed at the end of the run method of the plugin, even if an exception is thrown.

I've signed the [ECA](https://accounts.eclipse.org/users/bvester) and the commit itself.