### PR TITLE
switch min bin level to 8

### DIFF
--- a/jaxb-ri/boms/bom/pom.xml
+++ b/jaxb-ri/boms/bom/pom.xml
@@ -30,7 +30,7 @@
     <description>JAXB Bill of Materials (BOM)</description>
 
     <properties>
-        <jaxb-api.version>2.3.3</jaxb-api.version>
+        <jaxb-api.version>2.3.2</jaxb-api.version>
         <jaxb-api-osgi.version>2.3</jaxb-api-osgi.version>
         <istack.version>3.0.9</istack.version>
         <fastinfoset.version>1.2.17</fastinfoset.version>

--- a/jaxb-ri/bundles/xjc/pom.xml
+++ b/jaxb-ri/bundles/xjc/pom.xml
@@ -190,6 +190,7 @@
                                     <directory>${dep.sources}</directory>
                                     <excludes>
                                         <exclude>**/*.java</exclude>
+                                        <exclude>com/sun/tools/xjc/MessageBundle*.properties</exclude>
                                     </excludes>
                                 </resource>
                                 <resource>
@@ -201,6 +202,13 @@
                                     <excludes>
                                         <exclude>package-info.java</exclude>
                                     </excludes>
+                                </resource>
+                                <resource>
+                                    <directory>${dep.sources}</directory>
+                                    <includes>
+                                        <include>com/sun/tools/xjc/MessageBundle*.properties</include>
+                                    </includes>
+                                    <filtering>true</filtering>
                                 </resource>
                             </resources>
                         </configuration>

--- a/jaxb-ri/codemodel/pom.xml
+++ b/jaxb-ri/codemodel/pom.xml
@@ -38,7 +38,7 @@
         <spotbugs.version>3.1.12.2</spotbugs.version>
 
         <upper.java.level>9</upper.java.level>
-        <base.java.level>7</base.java.level>
+        <base.java.level>8</base.java.level>
     </properties>
 
     <modules>
@@ -56,13 +56,23 @@
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>buildnumber-maven-plugin</artifactId>
+                    <version>1.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>3.0.0</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>4.2.1</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -73,17 +83,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.1.1</version>
-                    <configuration>
-                        <doclint>none</doclint>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
-                    <configuration>
-                        <release>${upper.java.level}</release>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -138,14 +142,33 @@
                 <configuration>
                     <rules>
                         <requireJavaVersion>
-                            <version>[9,)</version>
+                            <version>[11,)</version>
                         </requireJavaVersion>
                         <requireMavenVersion>
-                            <version>[3.3.9,)</version>
+                            <version>[3.6.0,)</version>
                         </requireMavenVersion>
                         <DependencyConvergence/>
                     </rules>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>create</goal>
+                        </goals>
+                        <configuration>
+                            <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
+                            <timestampFormat>{0,date,yyyy-MM-dd'T'HH:mm:ssZ}</timestampFormat>
+                            <shortRevisionLength>7</shortRevisionLength>
+                            <revisionOnScmFailure>false</revisionOnScmFailure>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -175,17 +198,56 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>${upper.java.level}</release>
+                    <compilerArgs>
+                        <arg>-Xlint:all</arg>
+                    </compilerArgs>
+                </configuration>
                 <executions>
                     <execution>
-                        <id>default-compile</id>
-                        <configuration>
-                            <release>${upper.java.level}</release>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>base-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
                         <configuration>
                             <release>${base.java.level}</release>
+                            <excludes>
+                                <exclude>module-info.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                                <manifest>
+                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                </manifest>
+                                <manifestEntries>
+                                    <Implementation-Build-Id>${project.version} - ${scmBranch}-${buildNumber}, ${timestamp}</Implementation-Build-Id>
+                                </manifestEntries>
+                            </archive>
                         </configuration>
                     </execution>
                 </executions>
@@ -193,6 +255,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <Implementation-Build-Id>${project.version} - ${scmBranch}-${buildNumber}, ${timestamp}</Implementation-Build-Id>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/jaxb-ri/external/pom.xml
+++ b/jaxb-ri/external/pom.xml
@@ -40,7 +40,7 @@
         <spotbugs.version>3.1.12.2</spotbugs.version>
 
         <upper.java.level>9</upper.java.level>
-        <base.java.level>7</base.java.level>
+        <base.java.level>8</base.java.level>
     </properties>
 
     <modules>
@@ -58,13 +58,23 @@
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>buildnumber-maven-plugin</artifactId>
+                    <version>1.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>3.0.0</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>4.2.1</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -75,17 +85,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.1.1</version>
-                    <configuration>
-                        <doclint>none</doclint>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
-                    <configuration>
-                        <release>${upper.java.level}</release>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -140,14 +144,33 @@
                 <configuration>
                     <rules>
                         <requireJavaVersion>
-                            <version>[9,)</version>
+                            <version>[11,)</version>
                         </requireJavaVersion>
                         <requireMavenVersion>
-                            <version>[3.3.9,)</version>
+                            <version>[3.6.0,)</version>
                         </requireMavenVersion>
                         <DependencyConvergence/>
                     </rules>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>create</goal>
+                        </goals>
+                        <configuration>
+                            <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
+                            <timestampFormat>{0,date,yyyy-MM-dd'T'HH:mm:ssZ}</timestampFormat>
+                            <shortRevisionLength>7</shortRevisionLength>
+                            <revisionOnScmFailure>false</revisionOnScmFailure>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -177,17 +200,56 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>${upper.java.level}</release>
+                    <compilerArgs>
+                        <arg>-Xlint:all</arg>
+                    </compilerArgs>
+                </configuration>
                 <executions>
                     <execution>
-                        <id>default-compile</id>
-                        <configuration>
-                            <release>${upper.java.level}</release>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>base-compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
                         <configuration>
                             <release>${base.java.level}</release>
+                            <excludes>
+                                <exclude>module-info.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                                <manifest>
+                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                </manifest>
+                                <manifestEntries>
+                                    <Implementation-Build-Id>${project.version} - ${scmBranch}-${buildNumber}, ${timestamp}</Implementation-Build-Id>
+                                </manifestEntries>
+                            </archive>
                         </configuration>
                     </execution>
                 </executions>
@@ -195,6 +257,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <Implementation-Build-Id>${project.version} - ${scmBranch}-${buildNumber}, ${timestamp}</Implementation-Build-Id>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/jaxb-ri/external/relaxng-datatype/src/main/java/com/sun/tools/rngdatatype/helpers/ParameterlessDatatypeBuilder.java
+++ b/jaxb-ri/external/relaxng-datatype/src/main/java/com/sun/tools/rngdatatype/helpers/ParameterlessDatatypeBuilder.java
@@ -47,7 +47,7 @@ import com.sun.tools.rngdatatype.ValidationContext;
  * 
  * <p>
  * Typical usage would be:
- * <PRE><XMP>
+ * <PRE>
  * class MyDatatypeLibrary implements DatatypeLibrary {
  *     ....
  *     DatatypeBuilder createDatatypeBuilder( String typeName ) {
@@ -55,7 +55,7 @@ import com.sun.tools.rngdatatype.ValidationContext;
  *     }
  *     ....
  * }
- * </XMP></PRE>
+ * </PRE>
  * 
  * @author <a href="mailto:kohsuke.kawaguchi@sun.com">Kohsuke KAWAGUCHI</a>
  */

--- a/jaxb-ri/external/relaxng-datatype/src/main/java/com/sun/tools/rngdatatype/helpers/StreamingValidatorImpl.java
+++ b/jaxb-ri/external/relaxng-datatype/src/main/java/com/sun/tools/rngdatatype/helpers/StreamingValidatorImpl.java
@@ -49,7 +49,7 @@ import com.sun.tools.rngdatatype.ValidationContext;
  * 
  * <p>
  * Typical usage would be:
- * <PRE><XMP>
+ * <PRE>
  * class MyDatatype implements Datatype {
  *     ....
  *     public DatatypeStreamingValidator createStreamingValidator( ValidationContext context ) {
@@ -57,7 +57,7 @@ import com.sun.tools.rngdatatype.ValidationContext;
  *     }
  *     ....
  * }
- * </XMP></PRE>
+ * </PRE>
  * 
  * @author <a href="mailto:kohsuke.kawaguchi@sun.com">Kohsuke KAWAGUCHI</a>
  */

--- a/jaxb-ri/pom.xml
+++ b/jaxb-ri/pom.xml
@@ -96,7 +96,7 @@
         <felix.osgi.core>6.0.0</felix.osgi.core>
         <jmockit.version>1.34</jmockit.version>
         <mrjar.sourceDirectory>${project.basedir}/src/main/java-mr</mrjar.sourceDirectory>
-        <base.java.level>7</base.java.level>
+        <base.java.level>8</base.java.level>
         <upper.java.level>9</upper.java.level>
         <root.dir>${session.executionRootDirectory}/..</root.dir>
         <oss.disallow.snapshots>true</oss.disallow.snapshots>
@@ -182,8 +182,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
                     <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
                         <compilerArgs>
                             <arg>-Xlint:all</arg>
                             <!--<XDignore.symbol.file/>-->
@@ -247,7 +247,6 @@
                         <detectJavaApiLink>false</detectJavaApiLink>
                         <detectOfflineLinks>false</detectOfflineLinks>
                         <aggregate>false</aggregate>
-                        <doclint>none</doclint>
                         <dependencySourceExcludes>
                             <dependencySourceExclude>com.sun.xml.bind:*</dependencySourceExclude>
                             <dependencySourceExclude>com.sun.tools.xjc:*</dependencySourceExclude>

--- a/jaxb-ri/txw/compiler/pom.xml
+++ b/jaxb-ri/txw/compiler/pom.xml
@@ -67,6 +67,21 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>--add-reads</arg>
+                                <arg>com.sun.tools.txw2=ALL-UNNAMED</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/jaxb-ri/txw/compiler/src/main/java/com/sun/tools/txw2/TxwOptions.java
+++ b/jaxb-ri/txw/compiler/src/main/java/com/sun/tools/txw2/TxwOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -49,7 +49,7 @@ public class TxwOptions {
 
     /**
      * If true, generate attribute/value methods that
-     * returns the <tt>this</tt> object for chaining.
+     * returns the <code>this</code> object for chaining.
      */
     public boolean chainMethod;
 

--- a/jaxb-ri/txw/compiler/src/main/java/module-info.java
+++ b/jaxb-ri/txw/compiler/src/main/java/module-info.java
@@ -16,7 +16,4 @@ module com.sun.tools.txw2 {
     requires com.sun.tools.rngom;
     requires com.sun.codemodel;
 
-    requires ant;
-    requires ant.launcher;
-    requires args4j;
 }

--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/addon/episode/PluginImpl.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/addon/episode/PluginImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/jaxb-ri/xsom/pom.xml
+++ b/jaxb-ri/xsom/pom.xml
@@ -43,7 +43,7 @@
 
         <relaxng.version>2.3.2</relaxng.version>
         <upper.java.level>9</upper.java.level>
-        <base.java.level>7</base.java.level>
+        <base.java.level>8</base.java.level>
     </properties>
 
     <dependencies>
@@ -70,13 +70,23 @@
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>buildnumber-maven-plugin</artifactId>
+                    <version>1.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>3.0.0</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>4.2.1</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -87,9 +97,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.1.1</version>
-                    <configuration>
-                        <doclint>none</doclint>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -145,6 +152,25 @@
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>create</goal>
+                        </goals>
+                        <configuration>
+                            <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
+                            <timestampFormat>{0,date,yyyy-MM-dd'T'HH:mm:ssZ}</timestampFormat>
+                            <shortRevisionLength>7</shortRevisionLength>
+                            <revisionOnScmFailure>false</revisionOnScmFailure>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
                 <version>2.5.1</version>
                 <configuration>
@@ -161,15 +187,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>${upper.java.level}</release>
+                    <compilerArgs>
+                        <arg>-Xlint:all</arg>
+                    </compilerArgs>
+                </configuration>
                 <executions>
-                    <execution>
-                        <id>default-compile</id>
-                        <configuration>
-                            <release>${upper.java.level}</release>
-                            <source>${upper.java.level}</source>
-                            <target>${upper.java.level}</target>
-                        </configuration>
-                    </execution>
                     <execution>
                         <id>base-compile</id>
                         <goals>
@@ -198,10 +222,10 @@
                 <configuration>
                     <rules>
                         <requireJavaVersion>
-                            <version>[9,)</version>
+                            <version>[11,)</version>
                         </requireJavaVersion>
                         <requireMavenVersion>
-                            <version>[3.3.9,)</version>
+                            <version>[3.6.0,)</version>
                         </requireMavenVersion>
                         <DependencyConvergence/>
                     </rules>
@@ -229,6 +253,61 @@
                                 </resource>
                             </resources>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                            <configuration>
+                                <archive>
+                                    <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                                    <manifest>
+                                        <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                    </manifest>
+                                    <manifestEntries>
+                                        <Implementation-Build-Id>${project.version} - ${scmBranch}-${buildNumber}, ${timestamp}</Implementation-Build-Id>
+                                    </manifestEntries>
+                                </archive>
+                            </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <Implementation-Build-Id>${project.version} - ${scmBranch}-${buildNumber}, ${timestamp}</Implementation-Build-Id>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
remove the need for doclint:none in javadoc
revert api dependency to the version available in central

also fixes #1342 

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>