### PR TITLE
c.s.t.x.g.bean should be exported to impl instead of API

### DIFF
--- a/jaxb-ri/bundles/xjc/src/main/java/module-info.java
+++ b/jaxb-ri/bundles/xjc/src/main/java/module-info.java
@@ -28,7 +28,7 @@ module com.sun.tools.xjc {
 
     exports com.sun.tools.xjc;
     exports com.sun.tools.xjc.api;
-    exports com.sun.tools.xjc.generator.bean to java.xml.bind;
+    exports com.sun.tools.xjc.generator.bean to com.sun.xml.bind;
     exports com.sun.tools.xjc.model;
     exports com.sun.tools.xjc.model.nav;
     exports com.sun.tools.xjc.outline;


### PR DESCRIPTION
Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>