### PR TITLE
xjc.sh fix for JAVA_HOME variables with spaces

### DIFF
--- a/jaxb-ri/bundles/ri/src/main/resources/bin/xjc.sh
+++ b/jaxb-ri/bundles/ri/src/main/resources/bin/xjc.sh
@@ -66,7 +66,7 @@ then
     unset JAVA_TOOL_OPTIONS
 fi
 
-JAVA_VERSION=`${JAVA} -version 2>&1 | head -n 1 | cut -d'"' -f2 | sed -E 's/^(1\.)?([0-9]+).+$/\2/'`
+JAVA_VERSION=$("$JAVA" -version 2>&1 | head -n 1 | cut -d'"' -f2 | sed -E 's/^(1\.)?([0-9]+).+$/\2/')
 echo "Java major version: ${JAVA_VERSION}"
 
 if [ -n "$_OPTS" ]


### PR DESCRIPTION
Executed with cygwin with different java homes.

> 
> jbescos@JBESCOS-CZ ~
> $ echo $JAVA_HOME
> C:\Program Files (x86)\Java\jdk1.8.0_231
> 
> jbescos@JBESCOS-CZ /cygdrive/c/workspaceJAXB/jaxb-ri/jaxb-ri/bundles/ri/src/main/resources/bin
> $ ./xjc.sh
> Java major version: 8
> Error: Could not find or load main class com.sun.tools.xjc.XJCFacade

> 
> jbescos@JBESCOS-CZ /cygdrive/c/workspaceJAXB/jaxb-ri/jaxb-ri/bundles/ri/src/main/resources/bin
> $ echo $JAVA_HOME
> C:\Program Files\Java\jdk1.8.0_231
> 
> jbescos@JBESCOS-CZ /cygdrive/c/workspaceJAXB/jaxb-ri/jaxb-ri/bundles/ri/src/main/resources/bin
> $ ./xjc.sh
> Java major version: 8
> Error: Could not find or load main class com.sun.tools.xjc.XJCFacade

And in Ubuntu WLS in Windows. To make sure my changes didn't break it in Linux.

> jbescos@JBESCOS-CZ:/mnt/c/workspaceJAXB/jaxb-ri/jaxb-ri/bundles/ri/src/main/resources/bin$ echo $JAVA_HOME                                                                                                                                   /usr/lib/jvm/jdk-13.0.1                                                                                                                                                                                                                      

> jbescos@JBESCOS-CZ:/mnt/c/workspaceJAXB/jaxb-ri/jaxb-ri/bundles/ri/src/main/resources/bin$ ./xjc.sh                                                                                                                                          Java major version: 13                                                                                                                                                                                                                       Error occurred during initialization of boot layer                                                                                                                                                                                           java.lang.module.FindException: Module com.sun.tools.xjc not found