### PR TITLE
Fix incorrect header for package javax.xml.catalog in OSGi manifest file

### DIFF
--- a/jaxb-ri/bundles/osgi/osgi/pom.xml
+++ b/jaxb-ri/bundles/osgi/osgi/pom.xml
@@ -330,7 +330,7 @@
                                     javax.swing.border,
                                     javax.swing.tree,
                                     javax.tools,
-                                    javax.xml.catalog;optional=true,
+                                    javax.xml.catalog;resolution:=optional,
                                     javax.xml.datatype,
                                     javax.xml.namespace,
                                     javax.xml.parsers,

--- a/jaxb-ri/bundles/xjc/pom.xml
+++ b/jaxb-ri/bundles/xjc/pom.xml
@@ -384,7 +384,7 @@
                                 </Export-Package>
                                 <Import-Package>
                                     javax.activation;version=!,
-                                    javax.xml.catalog;optional=true,
+                                    javax.xml.catalog;resolution:=optional,
                                     *
                                 </Import-Package>
                             </instructions>


### PR DESCRIPTION
Signed-off-by: Pieter-Jan Pintens <pieter-jan.pintens@unifiedpost.com>