### PR TITLE
#1209: JAVA 10 modules break old kludge

### DIFF
--- a/jaxb-ri/runtime/impl/src/main/java/com/sun/xml/bind/api/JAXBRIContext.java
+++ b/jaxb-ri/runtime/impl/src/main/java/com/sun/xml/bind/api/JAXBRIContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -38,7 +38,7 @@ import java.util.HashMap;
  *
  * <p>
  * <b>Subject to change without notice</b>.
- * 
+ *
  * @since 2.0 EA1
  * @author
  *     Kohsuke Kawaguchi (kohsuke.kawaguchi@sun.com)
@@ -120,9 +120,9 @@ public abstract class JAXBRIContext extends JAXBContext {
        @Nullable Map<Class,Class> subclassReplacements,
        @Nullable String defaultNamespaceRemap, boolean c14nSupport,
        @Nullable RuntimeAnnotationReader ar,
-       boolean xmlAccessorFactorySupport, 
-       boolean allNillable, 
-       boolean retainPropertyInfo, 
+       boolean xmlAccessorFactorySupport,
+       boolean allNillable,
+       boolean retainPropertyInfo,
        boolean supressAccessorWarnings) throws JAXBException {
         Map<String, Object> properties = new HashMap<String, Object>();
         if (typeRefs != null) properties.put(JAXBRIContext.TYPE_REFERENCES, typeRefs);
@@ -512,7 +512,7 @@ public abstract class JAXBRIContext extends JAXBContext {
 
     /**
      * If true XML security features when parsing XML documents will be disabled.
-     * The default value is false. 
+     * The default value is false.
      *
      * Boolean
      * @since 2.2.6
@@ -527,5 +527,14 @@ public abstract class JAXBRIContext extends JAXBContext {
      * @since 2.3.0
      */
     public static final String BACKUP_WITH_PARENT_NAMESPACE = "com.sun.xml.bind.backupWithParentNamespace";
+
+    /**
+     * The maximum number of errors to report. Use negative value to report all errors.
+     * The default value is 10.
+     *
+     * Boolean
+     * @since 2.3.3
+     */
+    public static final String MAX_ERRORS = "com.sun.xml.bind.maxErrorsCount";
 
 }

--- a/jaxb-ri/runtime/impl/src/main/java/com/sun/xml/bind/v2/ContextFactory.java
+++ b/jaxb-ri/runtime/impl/src/main/java/com/sun/xml/bind/v2/ContextFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -114,6 +114,11 @@ public class ContextFactory {
             throw new JAXBException(Messages.INVALID_TYPE_IN_MAP.format(),e);
         }
 
+        Integer maxErrorsCount = getPropertyValue(properties, JAXBRIContext.MAX_ERRORS, Integer.class);
+        if (maxErrorsCount == null) {
+            maxErrorsCount = 10;
+        }
+
         if(!properties.isEmpty()) {
             throw new JAXBException(Messages.UNSUPPORTED_PROPERTY.format(properties.keySet().iterator().next()));
         }
@@ -132,6 +137,7 @@ public class ContextFactory {
         builder.setImprovedXsiTypeHandling(improvedXsiTypeHandling);
         builder.setDisableSecurityProcessing(disablesecurityProcessing);
         builder.setBackupWithParentNamespace(backupWithParentNamespace);
+        builder.setMaxErrorsCount(maxErrorsCount);
         return builder.build();
     }
 

--- a/jaxb-ri/runtime/impl/src/main/java/com/sun/xml/bind/v2/runtime/JAXBContextImpl.java
+++ b/jaxb-ri/runtime/impl/src/main/java/com/sun/xml/bind/v2/runtime/JAXBContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -227,14 +227,22 @@ public final class JAXBContextImpl extends JAXBRIContext {
     private Set<XmlNs> xmlNsSet = null;
 
     /**
-     * If true, despite the specification, unmarshall child element with parent namespace, if child namespace is not specified. 
+     * If true, despite the specification, unmarshall child element with parent namespace, if child namespace is not specified.
      * The default value is null for System {code}com.sun.xml.bind.backupWithParentNamespace{code} property to be used,
-     * and false is assumed if it's not set either. 
+     * and false is assumed if it's not set either.
      *
      * Boolean
      * @since 2.3.0
      */
     public Boolean backupWithParentNamespace = null;
+
+    /**
+     * The maximum number of errors unmarshall operation reports.  Use negative value to report all errors.
+     * The default value is 10.
+     *
+     * @since 2.3.3
+     */
+    public final int maxErrorsCount;
 
     /**
      * Returns declared XmlNs annotations (from package-level annotation XmlSchema
@@ -246,7 +254,7 @@ public final class JAXBContextImpl extends JAXBRIContext {
     }
 
     private JAXBContextImpl(JAXBContextBuilder builder) throws JAXBException {
-        
+
         this.defaultNsUri = builder.defaultNsUri;
         this.retainPropertyInfo = builder.retainPropertyInfo;
         this.annotationReader = builder.annotationReader;
@@ -259,6 +267,7 @@ public final class JAXBContextImpl extends JAXBRIContext {
         this.improvedXsiTypeHandling = builder.improvedXsiTypeHandling;
         this.disableSecurityProcessing = builder.disableSecurityProcessing;
         this.backupWithParentNamespace = builder.backupWithParentNamespace;
+        this.maxErrorsCount = builder.maxErrorsCount;
 
         Collection<TypeReference> typeRefs = builder.typeRefs;
 
@@ -391,7 +400,7 @@ public final class JAXBContextImpl extends JAXBRIContext {
 
         // no use for them now
         nameBuilder = null;
-        beanInfos = null;        
+        beanInfos = null;
     }
 
     /**
@@ -679,15 +688,15 @@ public final class JAXBContextImpl extends JAXBRIContext {
     public int getNumberOfLocalNames() {
         return nameList.localNames.length;
     }
-    
+
     public int getNumberOfElementNames() {
         return nameList.numberOfElementNames;
     }
-    
+
     public int getNumberOfAttributeNames() {
         return nameList.numberOfAttributeNames;
     }
-    
+
     /**
      * Creates a new identity transformer.
      */
@@ -736,8 +745,8 @@ public final class JAXBContextImpl extends JAXBRIContext {
 
     public UnmarshallerImpl createUnmarshaller() {
         return new UnmarshallerImpl(this,null);
-    }    
-        
+    }
+
     public Validator createValidator() {
         throw new UnsupportedOperationException(Messages.NOT_IMPLEMENTED_IN_2_0.format());
     }
@@ -799,7 +808,7 @@ public final class JAXBContextImpl extends JAXBRIContext {
             public void warning(SAXParseException exception) {
                 w[0] = exception;
             }
-            
+
             public void info(SAXParseException exception) {}
         });
 
@@ -991,7 +1000,7 @@ public final class JAXBContextImpl extends JAXBRIContext {
         Class[] newList = new Class[classes.length+1];
         System.arraycopy(classes,0,newList,0,classes.length);
         newList[classes.length] = clazz;
-        
+
         JAXBContextBuilder builder = new JAXBContextBuilder(this);
         builder.setClasses(newList);
         return builder.build();
@@ -1021,6 +1030,7 @@ public final class JAXBContextImpl extends JAXBRIContext {
         private boolean improvedXsiTypeHandling = true;
         private boolean disableSecurityProcessing = true;
         private Boolean backupWithParentNamespace = null; // null for System property to be used
+        private int maxErrorsCount;
 
         public JAXBContextBuilder() {};
 
@@ -1037,6 +1047,7 @@ public final class JAXBContextImpl extends JAXBRIContext {
             this.allNillable = baseImpl.allNillable;
             this.disableSecurityProcessing = baseImpl.disableSecurityProcessing;
             this.backupWithParentNamespace = baseImpl.backupWithParentNamespace;
+            this.maxErrorsCount = baseImpl.maxErrorsCount;
         }
 
         public JAXBContextBuilder setRetainPropertyInfo(boolean val) {
@@ -1104,12 +1115,17 @@ public final class JAXBContextImpl extends JAXBRIContext {
             return this;
         }
 
+        public JAXBContextBuilder setMaxErrorsCount(int maxErrorsCount) {
+            this.maxErrorsCount = maxErrorsCount;
+            return this;
+        }
+
         public JAXBContextImpl build() throws JAXBException {
 
             // fool-proof
             if (this.defaultNsUri == null) {
                 this.defaultNsUri = "";
-            }   
+            }
 
             if (this.subclassReplacements == null) {
                 this.subclassReplacements = Collections.emptyMap();

--- a/jaxb-ri/runtime/impl/src/main/java/com/sun/xml/bind/v2/runtime/unmarshaller/UnmarshallingContext.java
+++ b/jaxb-ri/runtime/impl/src/main/java/com/sun/xml/bind/v2/runtime/unmarshaller/UnmarshallingContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -46,8 +46,6 @@ import com.sun.xml.bind.v2.runtime.AssociationMap;
 import com.sun.xml.bind.v2.runtime.Coordinator;
 import com.sun.xml.bind.v2.runtime.JAXBContextImpl;
 import com.sun.xml.bind.v2.runtime.JaxBeanInfo;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.Locator;
@@ -174,7 +172,7 @@ public final class UnmarshallingContext extends Coordinator
      *
      * volatile is required to ensure that concurrent threads will see changed value
      */
-    private static volatile int errorsCounter = 10;
+    private static volatile int errorsCounter;
 
     /**
      * State information for each element.
@@ -399,6 +397,7 @@ public final class UnmarshallingContext extends Coordinator
         this.parent = _parent;
         this.assoc = assoc;
         this.root = this.current = new State(null);
+        errorsCounter = _parent.context.maxErrorsCount;
     }
 
     public void reset(InfosetScanner scanner,boolean isInplaceMode, JaxBeanInfo expectedType, IDResolver idResolver) {
@@ -1319,6 +1318,10 @@ public final class UnmarshallingContext extends Coordinator
     public boolean shouldErrorBeReported() throws SAXException {
         if (logger.isLoggable(Level.FINEST))
             return true;
+
+        if (errorsCounter < 0) {
+            return true;
+        }
 
         if (errorsCounter >= 0) {
             --errorsCounter;


### PR DESCRIPTION
Introduced `com.sun.xml.bind.maxErrorsCount` context property to increase or disable (using negative value) maximum number of errors reported by unmarshall operation

Fixes: #1209 

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>