### PR TITLE
Fix CClassInfoConstructor

### DIFF
--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/model/CClassInfo.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/model/CClassInfo.java
@@ -148,7 +148,7 @@ public final class CClassInfo extends AbstractCElement implements ClassInfo<NTyp
     public CClassInfo(Model model,JCodeModel cm, String fullName, Locator location, QName typeName, QName elementName, XSComponent source, CCustomizations customizations) {
         super(model,source,location,customizations);
         this.model = model;
-        int idx = fullName.indexOf('.');
+        int idx = fullName.lastIndexOf('.');
         if(idx<0) {
             this.parent = model.getPackage(cm.rootPackage());
             this.shortName = model.allocator.assignClassName(parent,fullName);


### PR DESCRIPTION
closes #1114 

Use lastIndexOf to construct the correct parent and shortName from fullname.

