### PR TITLE
Use StackWalker API to get the caller class

### DIFF
--- a/jaxb-ri/core/pom.xml
+++ b/jaxb-ri/core/pom.xml
@@ -50,6 +50,76 @@
             <groupId>com.sun.istack</groupId>
             <artifactId>istack-commons-runtime</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-mr-resource</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${mrjar.sourceDirectory}</directory>
+                                    <targetPath>META-INF/versions</targetPath>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile-mr</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <compileSourceRoots>
+                                <compileSourceRoot>${mrjar.sourceDirectory}/${upper.java.level}</compileSourceRoot>
+                            </compileSourceRoots>
+                            <outputDirectory>${project.build.outputDirectory}/META-INF/versions/${upper.java.level}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Multi-Release>true</Multi-Release>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Multi-Release>true</Multi-Release>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/jaxb-ri/core/src/main/java-mr/9/org/glassfish/jaxb/core/StackHelper.java
+++ b/jaxb-ri/core/src/main/java-mr/9/org/glassfish/jaxb/core/StackHelper.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package org.glassfish.jaxb.core;
+
+import java.lang.StackWalker.StackFrame;
+
+/**
+ * Utils for stack trace analysis in Java 9+.
+ * 
+ * @author Philippe Marschall
+ */
+final class StackHelper {
+    private StackHelper() {}   // no instanciation
+
+    /**
+     * Returns the name of the calling class of the second method in the call chain of this method.
+     * 
+     * @return the name of the caller class
+     * @throws SecurityException in case a security manager is installed that
+     *                           prevents stack introspection
+     */
+    static String getCallerClassName() {
+        return StackWalker.getInstance()
+                .walk(frames ->
+                                frames.map(StackFrame::getClassName)
+                                      .skip(2L)
+                                      .findFirst()
+                                      .get());
+    }
+}

--- a/jaxb-ri/core/src/main/java/org/glassfish/jaxb/core/StackHelper.java
+++ b/jaxb-ri/core/src/main/java/org/glassfish/jaxb/core/StackHelper.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package org.glassfish.jaxb.core;
+
+/**
+ * Utils for stack trace analysis. Indirection so that a more efficient
+ * implementation can be used in later Java versions.
+ * 
+ * @author Philippe Marschall
+ */
+final class StackHelper {
+    private StackHelper() {}   // no instanciation
+
+    /**
+     * Returns the name of the calling class of the second method in the call chain of this method.
+     * 
+     * @return the name of the caller class
+     * @throws SecurityException in case a security manager is installed that
+     *                           prevents stack introspection
+     */
+    static String getCallerClassName() {
+       StackTraceElement[] trace = new Exception().getStackTrace();
+       return trace[2].getClassName();
+    }
+}

--- a/jaxb-ri/core/src/main/java/org/glassfish/jaxb/core/Utils.java
+++ b/jaxb-ri/core/src/main/java/org/glassfish/jaxb/core/Utils.java
@@ -25,8 +25,7 @@ public final class Utils {
      */
     public static Logger getClassLogger() {
         try {
-            StackTraceElement[] trace = new Exception().getStackTrace();
-            return Logger.getLogger(trace[1].getClassName());
+            return Logger.getLogger(StackHelper.getCallerClassName());
         } catch( SecurityException e) {
             return Logger.getLogger("org.glassfish.jaxb.core"); // use the default
         }

--- a/jaxb-ri/core/src/test/java/org/glassfish/jaxb/core/UtilsTest.java
+++ b/jaxb-ri/core/src/test/java/org/glassfish/jaxb/core/UtilsTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package org.glassfish.jaxb.core;
+
+import junit.framework.TestCase;
+
+public class UtilsTest extends TestCase {
+    
+    public void testGetClassLogger() {
+        assertEquals(UtilsTest.class.getName(), Utils.getClassLogger().getName());
+    }
+
+}


### PR DESCRIPTION
Make jaxb-core a Multi-Release JAR and use the StackWalker API in
Java 9+ to get the caller class in Utils#getClassLogger. This avoids
throwing and catching exceptions to get the caller class.