### PR TITLE
#1466: ContextFinder always load the JAXBContext from jaxb-runtime 2.3.3

### DIFF
--- a/jaxb-ri/bundles/core/src/main/java/module-info.java
+++ b/jaxb-ri/bundles/core/src/main/java/module-info.java
@@ -48,5 +48,4 @@ module com.sun.xml.bind.core {
             com.sun.xml.ws,
             com.sun.tools.ws;
 
-//    uses jakarta.xml.bind.JAXBContextFactory with org.glassfish.jaxb.core.v2.JAXBContextFactory;
 }

--- a/jaxb-ri/bundles/osgi/osgi/src/main/java/module-info.java
+++ b/jaxb-ri/bundles/osgi/osgi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -123,13 +123,14 @@ module com.sun.xml.bind.osgi {
     exports com.sun.tools.rngdatatype;
     exports com.sun.tools.rngdatatype.helpers;
 
+    opens org.glassfish.jaxb.runtime.v2.runtime.reflect.opt to jakarta.xml.bind;
+    opens org.glassfish.jaxb.runtime.v2.schemagen to jakarta.xml.bind;
+    opens org.glassfish.jaxb.runtime.v2.schemagen.xmlschema to jakarta.xml.bind;
+    opens org.glassfish.jaxb.runtime.v2 to jakarta.xml.bind;
     opens com.sun.tools.xjc.reader.xmlschema.bindinfo to jakarta.xml.bind;
 
-    uses jakarta.xml.bind.JAXBContextFactory;
     uses com.sun.tools.xjc.Plugin;
 
-    provides jakarta.xml.bind.JAXBContextFactory with
-        org.glassfish.jaxb.runtime.v2.JAXBContextFactory;
     provides com.sun.tools.xjc.Plugin with
         com.sun.tools.xjc.addon.accessors.PluginImpl,
         com.sun.tools.xjc.addon.at_generated.PluginImpl,

--- a/jaxb-ri/bundles/runtime/src/main/java/module-info.java
+++ b/jaxb-ri/bundles/runtime/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -7,8 +7,6 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-
-import org.glassfish.jaxb.runtime.v2.JAXBContextFactory;
 
 module com.sun.xml.bind {
     requires java.compiler;
@@ -35,5 +33,9 @@ module com.sun.xml.bind {
     exports org.glassfish.jaxb.runtime.v2.schemagen.xmlschema;
     exports org.glassfish.jaxb.runtime.v2.util;
 
-    provides jakarta.xml.bind.JAXBContextFactory with JAXBContextFactory;
+    opens org.glassfish.jaxb.runtime.v2.runtime.reflect.opt to jakarta.xml.bind;
+    opens org.glassfish.jaxb.runtime.v2.schemagen to jakarta.xml.bind;
+    opens org.glassfish.jaxb.runtime.v2.schemagen.xmlschema to jakarta.xml.bind;
+    opens org.glassfish.jaxb.runtime.v2 to jakarta.xml.bind;
+
 }

--- a/jaxb-ri/core/src/main/java/module-info.java
+++ b/jaxb-ri/core/src/main/java/module-info.java
@@ -50,6 +50,4 @@ module org.glassfish.jaxb.core {
             com.sun.xml.ws.rt,
             com.sun.tools.ws.wscompile;
 
-    uses jakarta.xml.bind.JAXBContextFactory;
-
 }

--- a/jaxb-ri/runtime/impl/pom.xml
+++ b/jaxb-ri/runtime/impl/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -123,6 +123,11 @@
                             !META-INF.*,
                             *
                         </Export-Package>
+                        <Import-Package>
+                            sun.misc;resolution:=optional,
+                            jdk.internal.misc;resolution:=optional,
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
                 <executions>

--- a/jaxb-ri/runtime/impl/src/main/java/module-info.java
+++ b/jaxb-ri/runtime/impl/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,8 +10,6 @@
 
 /**
  * The XML Binding (JAXB) RI modularization implementation.
- *
- * @uses jakarta.xml.bind.JAXBContextFactory
  *
  */
 module org.glassfish.jaxb.runtime {
@@ -45,10 +43,13 @@ module org.glassfish.jaxb.runtime {
     opens org.glassfish.jaxb.runtime.v2.runtime.reflect.opt to jakarta.xml.bind;
     opens org.glassfish.jaxb.runtime.v2.schemagen to jakarta.xml.bind;
     opens org.glassfish.jaxb.runtime.v2.schemagen.xmlschema to jakarta.xml.bind;
+
+    // The API is going to load us via reflection if no other implementation is found sooner.
+    // Note that it is NOT mandatory for the jakarta.xml.bind.JAXBContext
+    // implementation to implement that interface (v2.ContextFactory does not do that),
+    // so we cannot use provides jakarta.xml.bind.JAXBContext with v2.ContextFactory here
+    // and we have to rely on accessibility of our META-INF/services/jakarta.xml.bind.JAXBContext
+    // resource by the API
     opens org.glassfish.jaxb.runtime.v2 to jakarta.xml.bind;
 
-    uses jakarta.xml.bind.JAXBContextFactory;
-
-    provides jakarta.xml.bind.JAXBContextFactory
-            with org.glassfish.jaxb.runtime.v2.JAXBContextFactory;
 }

--- a/jaxb-ri/runtime/impl/src/main/resources/META-INF/services/jakarta.xml.bind.JAXBContextFactory
+++ b/jaxb-ri/runtime/impl/src/main/resources/META-INF/services/jakarta.xml.bind.JAXBContextFactory
@@ -1,1 +1,0 @@
-org.glassfish.jaxb.runtime.v2.JAXBContextFactory


### PR DESCRIPTION
fixes #1466 