### PR TITLE
 #1466: ContextFinder always load the JAXBContext from jaxb-runtime 2.3.3

### DIFF
--- a/jaxb-ri/bundles/osgi/osgi/src/main/java/module-info.java
+++ b/jaxb-ri/bundles/osgi/osgi/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -111,12 +111,14 @@ module com.sun.xml.bind.osgi {
     exports com.sun.tools.rngdatatype;
     exports com.sun.tools.rngdatatype.helpers;
 
+    opens com.sun.xml.bind.v2.runtime.reflect.opt to java.xml.bind;
+    opens com.sun.xml.bind.v2.schemagen to java.xml.bind;
+    opens com.sun.xml.bind.v2.schemagen.xmlschema to java.xml.bind;
+    opens com.sun.xml.bind.v2 to java.xml.bind;
     opens com.sun.tools.xjc.reader.xmlschema.bindinfo to java.xml.bind;
 
-    uses javax.xml.bind.JAXBContextFactory;
     uses com.sun.tools.xjc.Plugin;
 
-    provides javax.xml.bind.JAXBContextFactory with com.sun.xml.bind.v2.JAXBContextFactory;
     provides com.sun.tools.xjc.Plugin with
         com.sun.tools.xjc.addon.accessors.PluginImpl,
         com.sun.tools.xjc.addon.at_generated.PluginImpl,

--- a/jaxb-ri/bundles/runtime/src/main/java/module-info.java
+++ b/jaxb-ri/bundles/runtime/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -54,5 +54,9 @@ module com.sun.xml.bind {
             com.sun.xml.ws,
             com.sun.tools.ws;
 
-    provides javax.xml.bind.JAXBContextFactory with com.sun.xml.bind.v2.JAXBContextFactory;
+    opens com.sun.xml.bind.v2.runtime.reflect.opt to java.xml.bind;
+    opens com.sun.xml.bind.v2.schemagen to java.xml.bind;
+    opens com.sun.xml.bind.v2.schemagen.xmlschema to java.xml.bind;
+    opens com.sun.xml.bind.v2 to java.xml.bind;
+
 }

--- a/jaxb-ri/runtime/impl/pom.xml
+++ b/jaxb-ri/runtime/impl/pom.xml
@@ -139,6 +139,8 @@
                         <Multi-Release>true</Multi-Release>
                         <Import-Package>
                             javax.activation;version=!,
+                            sun.misc;resolution:=optional,
+                            jdk.internal.misc;resolution:=optional,
                             *
                         </Import-Package>
                         <Export-Package>

--- a/jaxb-ri/runtime/impl/src/main/java/module-info.java
+++ b/jaxb-ri/runtime/impl/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,8 +10,6 @@
 
 /**
  * The XML Binding (JAXB) RI modularization implementation.
- *
- * @uses javax.xml.bind.JAXBContextFactory
  *
  */
 module org.glassfish.jaxb.runtime {
@@ -49,9 +47,17 @@ module org.glassfish.jaxb.runtime {
     exports com.sun.xml.bind.v2.schemagen.xmlschema;
     exports com.sun.xml.bind.v2.util;
 
+    opens com.sun.xml.bind.v2.runtime.reflect.opt to java.xml.bind;
+    opens com.sun.xml.bind.v2.schemagen to java.xml.bind;
+    opens com.sun.xml.bind.v2.schemagen.xmlschema to java.xml.bind;
+
+    // The API is going to load us via reflection if no other implementation is found sooner.
+    // Note that it is NOT mandatory for the javax.xml.bind.JAXBContext
+    // implementation to implement that interface (v2.ContextFactory does not do that),
+    // so we cannot use provides javax.xml.bind.JAXBContext with v2.ContextFactory here
+    // and we have to rely on accessibility of our META-INF/services/javax.xml.bind.JAXBContext
+    // resource by the API
+    opens com.sun.xml.bind.v2 to java.xml.bind;
+
     opens com.sun.xml.bind.v2.model.nav to org.glassfish.jaxb.xjc;
-
-    uses javax.xml.bind.JAXBContextFactory;
-
-    provides javax.xml.bind.JAXBContextFactory with com.sun.xml.bind.v2.JAXBContextFactory;
 }

--- a/jaxb-ri/runtime/impl/src/main/resources/META-INF/services/javax.xml.bind.JAXBContextFactory
+++ b/jaxb-ri/runtime/impl/src/main/resources/META-INF/services/javax.xml.bind.JAXBContextFactory
@@ -1,1 +1,0 @@
-com.sun.xml.bind.v2.JAXBContextFactory


### PR DESCRIPTION
Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>