### PR TITLE
JCodeModel.parseType(String) silently ignores type params in specific scenarios

### DIFF
--- a/jaxb-ri/codemodel/codemodel/src/test/java/com/sun/codemodel/Issue1505Test.java
+++ b/jaxb-ri/codemodel/codemodel/src/test/java/com/sun/codemodel/Issue1505Test.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package com.sun.codemodel;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Ignore;
+
+public class Issue1505Test {
+    
+    private void checks(String test) throws ClassNotFoundException {
+        checks(test, test);
+    }
+    
+    private void checks(String expected, String test) throws ClassNotFoundException {
+        JCodeModel model = new JCodeModel();
+        JType type = model.parseType(test);
+        assertEquals(expected, type.fullName());
+    }
+
+    @Test
+    public void test1() throws ClassNotFoundException {
+        checks("Map<K,Pair<X,Y>>");
+    }
+
+    @Test
+    public void test2() throws ClassNotFoundException {
+        checks("Map<Pair<X,Y>,V>");
+    }
+
+    @Test
+    public void test3() throws ClassNotFoundException {
+        checks("M<K,V<X>>");
+    }
+
+    @Test
+    public void test4() throws ClassNotFoundException {
+        checks("M<K<X>,V>");
+    }
+    
+    @Test
+    public void test5() throws ClassNotFoundException {
+        checks("A<B,C>");
+    }
+
+    @Test
+    public void test6() throws ClassNotFoundException {
+        checks("M<K>");
+    }
+
+    @Test
+    public void test7() throws ClassNotFoundException {
+        checks("M<K<Q>>");
+    }
+
+    @Test
+    public void test8() throws ClassNotFoundException {
+        checks("M<K,V>");
+    }
+
+    @Test
+    public void test9() throws ClassNotFoundException {
+        checks("M<K,V<Q>>");
+    }
+
+    @Test
+    @Ignore("Not supported")
+    public void test10() throws ClassNotFoundException {
+        checks("java.util.Map<K extends ?,V extends ?>");
+    }
+
+    @Test
+    public void test11() throws ClassNotFoundException {
+        checks("Map<Key,Value<Que>>");
+    }
+
+    @Test
+    public void test12() throws ClassNotFoundException {
+        checks("M<K<T>,V>");
+    }
+
+    @Test
+    public void test13() throws ClassNotFoundException {
+        checks("M<T,Q,R>");
+    }
+
+    @Test
+    public void test14() throws ClassNotFoundException {
+        checks("M<A,B<C,D<E>,F<G>>>");
+    }
+
+    @Test
+    public void test15() throws ClassNotFoundException {
+        checks("M<A,B[]<C[],D[]<E>,F<G[]>>>");
+    }
+    
+    @Test
+    public void test16() throws ClassNotFoundException {
+        checks("M<? extends A,? extends B>");
+    }
+
+    @Test
+    @Ignore("Not supported")
+    public void test17() throws ClassNotFoundException {
+        checks("M<A extends Object,B extends Object>");
+    }
+
+    @Test
+    public void test18() throws ClassNotFoundException {
+        checks("java.lang.Object");
+    }
+
+    @Test
+    public void test19() throws ClassNotFoundException {
+        checks("java.util.ArrayList<String>");
+    }
+}

--- a/jaxb-ri/codemodel/codemodel/src/test/java/com/sun/codemodel/Issue1505Test.java
+++ b/jaxb-ri/codemodel/codemodel/src/test/java/com/sun/codemodel/Issue1505Test.java
@@ -10,118 +10,122 @@
 
 package com.sun.codemodel;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import org.junit.Ignore;
+import org.junit.Test;
 
 public class Issue1505Test {
-    
-    private void checks(String test) throws ClassNotFoundException {
+
+    private void checks(String test) {
         checks(test, test);
     }
-    
-    private void checks(String expected, String test) throws ClassNotFoundException {
+
+    private void checks(String expected, String test) {
         JCodeModel model = new JCodeModel();
-        JType type = model.parseType(test);
-        assertEquals(expected, type.fullName());
+        try {
+            JType type = model.parseType(test);
+            assertEquals(expected, type.fullName());
+        } catch (ClassNotFoundException e) {
+            fail(e.getMessage());
+        } 
     }
 
     @Test
-    public void test1() throws ClassNotFoundException {
+    public void test1() {
         checks("Map<K,Pair<X,Y>>");
     }
 
     @Test
-    public void test2() throws ClassNotFoundException {
+    public void test2() {
         checks("Map<Pair<X,Y>,V>");
     }
 
     @Test
-    public void test3() throws ClassNotFoundException {
+    public void test3() {
         checks("M<K,V<X>>");
     }
 
     @Test
-    public void test4() throws ClassNotFoundException {
+    public void test4() {
         checks("M<K<X>,V>");
     }
-    
+
     @Test
-    public void test5() throws ClassNotFoundException {
+    public void test5() {
         checks("A<B,C>");
     }
 
     @Test
-    public void test6() throws ClassNotFoundException {
+    public void test6() {
         checks("M<K>");
     }
 
     @Test
-    public void test7() throws ClassNotFoundException {
+    public void test7() {
         checks("M<K<Q>>");
     }
 
     @Test
-    public void test8() throws ClassNotFoundException {
+    public void test8() {
         checks("M<K,V>");
     }
 
     @Test
-    public void test9() throws ClassNotFoundException {
+    public void test9() {
         checks("M<K,V<Q>>");
     }
 
     @Test
     @Ignore("Not supported")
-    public void test10() throws ClassNotFoundException {
+    public void test10() {
         checks("java.util.Map<K extends ?,V extends ?>");
     }
 
     @Test
-    public void test11() throws ClassNotFoundException {
+    public void test11() {
         checks("Map<Key,Value<Que>>");
     }
 
     @Test
-    public void test12() throws ClassNotFoundException {
+    public void test12() {
         checks("M<K<T>,V>");
     }
 
     @Test
-    public void test13() throws ClassNotFoundException {
+    public void test13() {
         checks("M<T,Q,R>");
     }
 
     @Test
-    public void test14() throws ClassNotFoundException {
+    public void test14() {
         checks("M<A,B<C,D<E>,F<G>>>");
     }
 
     @Test
-    public void test15() throws ClassNotFoundException {
+    public void test15() {
         checks("M<A,B[]<C[],D[]<E>,F<G[]>>>");
     }
-    
+
     @Test
-    public void test16() throws ClassNotFoundException {
+    public void test16() {
         checks("M<? extends A,? extends B>");
     }
 
     @Test
     @Ignore("Not supported")
-    public void test17() throws ClassNotFoundException {
+    public void test17() {
         checks("M<A extends Object,B extends Object>");
     }
 
     @Test
-    public void test18() throws ClassNotFoundException {
+    public void test18() {
         checks("java.lang.Object");
     }
 
     @Test
-    public void test19() throws ClassNotFoundException {
+    public void test19() {
         checks("java.util.ArrayList<String>");
     }
 }


### PR DESCRIPTION
Relates to https://github.com/eclipse-ee4j/jaxb-ri/issues/1505

New implementation provide better result tests, but there is a common issue. It does not work well with '? extends T' and that type of strings.

The reason of this failure is that the new implementation simplifies the content and it passes it to the previous implementation. So this issue is propagated to the new implementation.

Here there are the test failures with previous implementation:
```
Failed tests:   test12(com.sun.codemodel.Issue1505Test): expected:<M<K<T>[,V]>> but was:<M<K<T>[]>>
  test14(com.sun.codemodel.Issue1505Test): expected:<M<A,B<C,D<E>[,F<G>]>>> but was:<M<A,B<C,D<E>[]>>>
  test15(com.sun.codemodel.Issue1505Test): expected:<M<A,B[]<C[],D[]<E>[,F<G[]>]>>> but was:<M<A,B[]<C[],D[]<E>[]>>>
  test2(com.sun.codemodel.Issue1505Test): expected:<Map<Pair<X,Y>[,V]>> but was:<Map<Pair<X,Y>[]>>
  test4(com.sun.codemodel.Issue1505Test): expected:<M<K<X>[,V]>> but was:<M<K<X>[]>>
Tests in error: 
  test10(com.sun.codemodel.Issue1505Test): java.util.Map<K extends ?,V extends ?>
  test17(com.sun.codemodel.Issue1505Test): M<A extends Object,B extends Object>
```
And here with the new one:
```
Failed tests:   test10(com.sun.codemodel.Issue1505Test): expected:<java.util.Map<K[ extends ?,V extends ?]>> but was:<java.util.Map<K[,V]>>
  test17(com.sun.codemodel.Issue1505Test): expected:<M<A[ extends Object,B extends Object]>> but was:<M<A[,B]>>
```
If we are fine with that issue, I can ignore that failed tests.