### PR TITLE
Fixed regex for java version

### DIFF
--- a/jaxb-ri/bundles/ri/src/main/resources/bin/xjc.sh
+++ b/jaxb-ri/bundles/ri/src/main/resources/bin/xjc.sh
@@ -67,7 +67,7 @@ then
     unset JAVA_TOOL_OPTIONS
 fi
 
-JAVA_VERSION=$("$JAVA" -version 2>&1 | head -n 1 | cut -d'"' -f2 | sed -E 's/^(1\.)?([0-9]+).+$/\2/')
+JAVA_VERSION=$("$JAVA" -version 2>&1 | head -n 1 | cut -d'"' -f2 | sed -E 's/^(1\.)?([0-9]+).*$/\2/')
 echo "Java major version: ${JAVA_VERSION}"
 
 if [ -n "$_OPTS" ]


### PR DESCRIPTION
The current Sed does not correctly handle java version strings that only include the major version: 
```
echo 'openjdk version "16" 2021-03-16' | java -version 2>&1 | head -n 1 | cut -d'"' -f2 | sed -E 's/^(foo)?([0-9]+).+$/\2/'
1
```

The fix is to change the regex from `+` to `*`:
```
$ echo 'openjdk version "16" 2021-03-16' | java -version 2>&1 | head -n 1 | cut -d'"' -f2 | sed -E 's/^(foo)?([0-9]+).*$/\2/'
16
```