### PR TITLE
Added a project url to jaxb-runtime

### DIFF
--- a/jaxb-ri/boms/bom-ext/pom.xml
+++ b/jaxb-ri/boms/bom-ext/pom.xml
@@ -31,6 +31,7 @@
         JAXB Bill of Materials (BOM) with all dependencies.
         If you are not sure - DON'T USE THIS BOM. Use com.sun.xml.bind:jaxb-bom instead.
     </description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <properties>
         <codemodel.version>${project.version}</codemodel.version>

--- a/jaxb-ri/boms/bom/pom.xml
+++ b/jaxb-ri/boms/bom/pom.xml
@@ -29,6 +29,7 @@
     <packaging>pom</packaging>
     <name>JAXB BOM</name>
     <description>JAXB Bill of Materials (BOM)</description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <properties>
         <xml.bind-api.version>3.0.1</xml.bind-api.version>

--- a/jaxb-ri/bundles/core/pom.xml
+++ b/jaxb-ri/bundles/core/pom.xml
@@ -28,6 +28,7 @@
     <packaging>jar</packaging>
     <name>Old JAXB Core</name>
     <description>Old JAXB Core module. Contains sources required by XJC, JXC and Runtime modules with dependencies.</description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <dependencies>
 

--- a/jaxb-ri/bundles/jxc/pom.xml
+++ b/jaxb-ri/bundles/jxc/pom.xml
@@ -30,6 +30,7 @@
     <description>
         Old JAXB schema generator.The *tool* to generate XML schema based on java classes.
     </description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <dependencies>
         <dependency>

--- a/jaxb-ri/bundles/osgi/osgi/pom.xml
+++ b/jaxb-ri/bundles/osgi/osgi/pom.xml
@@ -28,6 +28,7 @@
     <packaging>jar</packaging>
     <name>JAXB OSGI</name>
     <description>JAXB OSGI bundle</description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <dependencies>
         <dependency>

--- a/jaxb-ri/bundles/osgi/pom.xml
+++ b/jaxb-ri/bundles/osgi/pom.xml
@@ -27,6 +27,7 @@
     <packaging>pom</packaging>
     <name>JAXB OSGI parent</name>
     <description>Parent module of JAXB OSGI bundle</description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <profiles>
         <profile>

--- a/jaxb-ri/bundles/osgi/tests/pom.xml
+++ b/jaxb-ri/bundles/osgi/tests/pom.xml
@@ -27,6 +27,7 @@
         Tests for JAXB RI OSGi bundles.
         They should be in separate module because of dependency-hell of osgi and extra-osgi modules.
     </description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <dependencies>
         <dependency>

--- a/jaxb-ri/bundles/pom.xml
+++ b/jaxb-ri/bundles/pom.xml
@@ -27,6 +27,7 @@
     <packaging>pom</packaging>
     <name>JAXB bundles</name>
     <description>JAXB bundles module.</description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <properties>
         <spotbugs.skip>true</spotbugs.skip>

--- a/jaxb-ri/bundles/ri/pom.xml
+++ b/jaxb-ri/bundles/ri/pom.xml
@@ -28,6 +28,7 @@
     <packaging>pom</packaging>
     <name>JAXB RI</name>
     <description>JAXB RI standalone zipped bundle</description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <dependencies>
         <dependency>

--- a/jaxb-ri/bundles/runtime/pom.xml
+++ b/jaxb-ri/bundles/runtime/pom.xml
@@ -28,6 +28,7 @@
     <packaging>jar</packaging>
     <name>Old JAXB Runtime</name>
     <description>Old JAXB Runtime module. Contains sources required for runtime processing.</description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <dependencies>
         <dependency>

--- a/jaxb-ri/bundles/xjc/pom.xml
+++ b/jaxb-ri/bundles/xjc/pom.xml
@@ -32,6 +32,7 @@
         In other words: the *tool* to generate java classes for the given xml representation.
         <!--todo: finish me-->
     </description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <dependencies>
         <dependency>

--- a/jaxb-ri/codemodel/codemodel-annotation-compiler/pom.xml
+++ b/jaxb-ri/codemodel/codemodel-annotation-compiler/pom.xml
@@ -23,6 +23,7 @@
     <artifactId>codemodel-annotation-compiler</artifactId>
     <name>Codemodel Annotation Compiler</name>
     <description>The annotation compiler ant task for the CodeModel java source code generation library</description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <dependencies>
         <dependency>

--- a/jaxb-ri/codemodel/codemodel/pom.xml
+++ b/jaxb-ri/codemodel/codemodel/pom.xml
@@ -24,6 +24,7 @@
     <artifactId>codemodel</artifactId>
     <name>Codemodel Core</name>
     <description>The core functionality of the CodeModel java source code generation library</description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <properties>
         <spotbugs.exclude>${project.basedir}/exclude-codemodel.xml</spotbugs.exclude>

--- a/jaxb-ri/codemodel/pom.xml
+++ b/jaxb-ri/codemodel/pom.xml
@@ -26,6 +26,7 @@
     <packaging>pom</packaging>
     <name>Codemodel</name>
     <description>Java source code generation library</description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <licenses>
         <license>

--- a/jaxb-ri/core/pom.xml
+++ b/jaxb-ri/core/pom.xml
@@ -28,6 +28,7 @@
     <packaging>jar</packaging>
     <name>JAXB Core</name>
     <description>JAXB Core module. Contains sources required by XJC, JXC and Runtime modules.</description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <properties>
         <findbugs.exclude>${project.basedir}/exclude-core.xml</findbugs.exclude>

--- a/jaxb-ri/docs/pom.xml
+++ b/jaxb-ri/docs/pom.xml
@@ -27,6 +27,7 @@
     <packaging>pom</packaging>
     <name>JAXB Documentation parent</name>
     <description>JAXB Documentation parent.</description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <modules>
         <module>release-documentation</module>

--- a/jaxb-ri/docs/release-documentation/pom.xml
+++ b/jaxb-ri/docs/release-documentation/pom.xml
@@ -26,6 +26,7 @@
     <artifactId>jaxb-release-documentation</artifactId>
     <packaging>pom</packaging>
     <name>JAXB Release Documentation</name>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <build>
         <plugins>

--- a/jaxb-ri/docs/www/pom.xml
+++ b/jaxb-ri/docs/www/pom.xml
@@ -25,6 +25,7 @@
     <artifactId>jaxb-www</artifactId>
     <packaging>pom</packaging>
     <name>JAXB WWW Help files</name>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <build>
         <plugins>

--- a/jaxb-ri/external/pom.xml
+++ b/jaxb-ri/external/pom.xml
@@ -28,6 +28,7 @@
     <version>3.0.1-SNAPSHOT</version>
     <name>JAXB External parent</name>
     <description>JAXB External parent module. Contains sources for external components.</description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <licenses>
         <license>

--- a/jaxb-ri/external/relaxng-datatype/pom.xml
+++ b/jaxb-ri/external/relaxng-datatype/pom.xml
@@ -28,5 +28,6 @@
     <packaging>jar</packaging>
     <name>RelaxNG Datatype</name>
     <description>RelaxNG Datatype library.</description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
 </project>

--- a/jaxb-ri/external/rngom/pom.xml
+++ b/jaxb-ri/external/rngom/pom.xml
@@ -29,6 +29,7 @@
     <description>
         RNGOM is a RelaxNG Object model library (XSOM for RelaxNG).
     </description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <properties>
         <spotbugs.exclude>${project.basedir}/exclude-rngom.xml</spotbugs.exclude>

--- a/jaxb-ri/jxc/pom.xml
+++ b/jaxb-ri/jxc/pom.xml
@@ -31,6 +31,7 @@
         JAXB schema generator.The *tool* to generate XML schema based on java classes.
         <!--todo: finish me-->
     </description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <properties>
         <spotbugs.exclude>${project.basedir}/exclude-jxc.xml</spotbugs.exclude>

--- a/jaxb-ri/runtime/impl/pom.xml
+++ b/jaxb-ri/runtime/impl/pom.xml
@@ -28,6 +28,7 @@
     <packaging>jar</packaging>
     <name>JAXB Runtime</name>
     <description>JAXB (JSR 222) Reference Implementation</description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <properties>
         <spotbugs.exclude>${project.basedir}/exclude-runtime.xml</spotbugs.exclude>

--- a/jaxb-ri/runtime/pom.xml
+++ b/jaxb-ri/runtime/pom.xml
@@ -27,6 +27,7 @@
     <packaging>pom</packaging>
     <name>JAXB Runtime parent</name>
     <description>JAXB Runtime parent module. Contains sources used during runtime processing.</description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <modules>
         <module>impl</module>

--- a/jaxb-ri/samples/pom.xml
+++ b/jaxb-ri/samples/pom.xml
@@ -27,6 +27,7 @@
     <packaging>pom</packaging>
     <name>JAXB samples</name>
     <description>JAXB samples module. Contains sources for JAXB samples generation</description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <build>
         <plugins>

--- a/jaxb-ri/tools/osgi_tests/core/pom.xml
+++ b/jaxb-ri/tools/osgi_tests/core/pom.xml
@@ -26,6 +26,7 @@
     <artifactId>osgi-test-core</artifactId>
     <packaging>jar</packaging>
     <name>osgi-test-core</name>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jaxb-ri/tools/osgi_tests/jxc/pom.xml
+++ b/jaxb-ri/tools/osgi_tests/jxc/pom.xml
@@ -26,6 +26,7 @@
     <artifactId>osgi-test-jxc</artifactId>
     <packaging>jar</packaging>
     <name>osgi-test-jxc</name>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jaxb-ri/tools/osgi_tests/osgi/pom.xml
+++ b/jaxb-ri/tools/osgi_tests/osgi/pom.xml
@@ -26,6 +26,7 @@
     <artifactId>osgi-test-osgi</artifactId>
     <packaging>jar</packaging>
     <name>osgi-test-osgi</name>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jaxb-ri/tools/osgi_tests/parent/pom.xml
+++ b/jaxb-ri/tools/osgi_tests/parent/pom.xml
@@ -26,6 +26,7 @@
     <artifactId>osgi-test-parent</artifactId>
     <packaging>jar</packaging>
     <name>osgi-test-parent</name>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jaxb-ri/tools/osgi_tests/pom.xml
+++ b/jaxb-ri/tools/osgi_tests/pom.xml
@@ -27,6 +27,7 @@
     <packaging>pom</packaging>
     <name>Parent for osgi testing modules.</name>
     <description>Modules generate jars used for testing valid osgi manifests</description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <properties>
         <spotbugs.skip>true</spotbugs.skip>

--- a/jaxb-ri/tools/osgi_tests/runtime/pom.xml
+++ b/jaxb-ri/tools/osgi_tests/runtime/pom.xml
@@ -26,6 +26,7 @@
     <artifactId>osgi-test-runtime</artifactId>
     <packaging>jar</packaging>
     <name>osgi-test-runtime</name>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jaxb-ri/tools/osgi_tests/xjc/pom.xml
+++ b/jaxb-ri/tools/osgi_tests/xjc/pom.xml
@@ -26,6 +26,7 @@
     <artifactId>osgi-test-xjc</artifactId>
     <packaging>jar</packaging>
     <name>osgi-test-xjc</name>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/jaxb-ri/txw/compiler/pom.xml
+++ b/jaxb-ri/txw/compiler/pom.xml
@@ -29,6 +29,7 @@
     <description>
         JAXB schema generator.The *tool* to generate XML schema based on java classes.
     </description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <properties>
         <spotbugs.exclude>${project.basedir}/exclude-txwc2.xml</spotbugs.exclude>

--- a/jaxb-ri/txw/pom.xml
+++ b/jaxb-ri/txw/pom.xml
@@ -26,6 +26,7 @@
     <packaging>pom</packaging>
     <name>JAXB TXW parent</name>
     <description>JAXB TXW parent module. Contains sources for TXW component.</description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <modules>
         <module>compiler</module>

--- a/jaxb-ri/txw/runtime/pom.xml
+++ b/jaxb-ri/txw/runtime/pom.xml
@@ -29,6 +29,7 @@
     <description>
         TXW is a library that allows you to write XML documents.
     </description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <properties>
         <spotbugs.exclude>${project.basedir}/exclude-txw-runtime.xml</spotbugs.exclude>

--- a/jaxb-ri/xjc/pom.xml
+++ b/jaxb-ri/xjc/pom.xml
@@ -32,6 +32,7 @@
         In other words: the *tool* to generate java classes for the given xml representation.
         <!--todo: finish me-->
     </description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <properties>
         <spotbugs.threshold>Low</spotbugs.threshold>

--- a/jaxb-ri/xsom/pom.xml
+++ b/jaxb-ri/xsom/pom.xml
@@ -30,6 +30,7 @@
         documents and inspect information in them. It is expected to be useful for applications that need to take XML
         Schema as an input.
     </description>
+    <url>https://eclipse-ee4j.github.io/jaxb-ri/</url>
 
     <licenses>
         <license>


### PR DESCRIPTION
`jaxb-runtime` does not define a project URL in the pom file. In that case, maven inherits the value of the parent pom and appends the artifact id (see [maven documentation](https://maven.apache.org/ref/3.6.1/maven-model-builder/)).
By that maven resolves the URL to https://eclipse-ee4j.github.io/jaxb-ri/jaxb-runtime-parent/jaxb-runtime, which does not exist.

This PR fixes that issue by adding an explicit URL to the project.