### PR TITLE
update cm to src level 1.8,

### DIFF
--- a/jaxb-ri/bundles/runtime/src/main/java/module-info.java
+++ b/jaxb-ri/bundles/runtime/src/main/java/module-info.java
@@ -28,6 +28,7 @@ module com.sun.xml.bind {
     exports org.glassfish.jaxb.runtime.v2.model.impl;
     exports org.glassfish.jaxb.runtime.v2.model.runtime;
     exports org.glassfish.jaxb.runtime.v2.runtime;
+    exports org.glassfish.jaxb.runtime.v2.runtime.reflect;
     exports org.glassfish.jaxb.runtime.v2.runtime.unmarshaller;
     exports org.glassfish.jaxb.runtime.v2.schemagen;
     exports org.glassfish.jaxb.runtime.v2.schemagen.xmlschema;

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JAnnotationClassValue.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JAnnotationClassValue.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package com.sun.codemodel;
+
+/**
+ * Captures the Class or Enum value of the annotation.
+ *
+ */
+public final class JAnnotationClassValue extends JAnnotationValue {
+
+    private final JClass type;
+    private String param;
+
+    JAnnotationClassValue(JClass type) {
+        this.type = type;
+    }
+
+    JAnnotationClassValue(JEnumConstant en) {
+        this.type = en.type();
+        this.param = en.getName().substring(en.getName().lastIndexOf('.') + 1);
+    }
+
+
+    @Override
+    public void generate(JFormatter f) {
+        if (param != null) {
+            f.t(type).p('.').p(param);
+        } else {
+            f.t(type).p(".class");
+        }
+    }
+
+    public JClass type() {
+        return type;
+    }
+
+    public String value() {
+        return param;
+    }
+
+}

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JAnnotationStringValue.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JAnnotationStringValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -18,7 +18,7 @@ package com.sun.codemodel;
  * @author
  *     Bhakti Mehta (bhakti.mehta@sun.com)
  */
-final class JAnnotationStringValue extends JAnnotationValue {
+public final class JAnnotationStringValue extends JAnnotationValue {
 
     /**
      * The value of the Annotation member
@@ -29,7 +29,14 @@ final class JAnnotationStringValue extends JAnnotationValue {
         this.value = value;
     }
 
+    @Override
     public void generate(JFormatter f) {
         f.g(value);
     }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
 }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JArray.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -28,7 +28,7 @@ public final class JArray extends JExpressionImpl {
      */
     public JArray add(JExpression e) {
         if (exprs == null)
-            exprs = new ArrayList<JExpression>();
+            exprs = new ArrayList<>();
         exprs.add(e);
         return this;
     }
@@ -38,6 +38,7 @@ public final class JArray extends JExpressionImpl {
         this.size = size;
     }
 
+    @Override
     public void generate(JFormatter f) {
         
         // generally we produce new T[x], but when T is an array type (T=T'[])

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JArrayClass.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JArrayClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -32,46 +32,57 @@ final class JArrayClass extends JClass {
     }
     
     
+    @Override
     public String name() {
         return componentType.name()+"[]";
     }
     
+    @Override
     public String fullName() {
         return componentType.fullName()+"[]";
     }
 
+    @Override
     public String binaryName() {
         return componentType.binaryName()+"[]";
     }
 
+    @Override
     public void generate(JFormatter f) {
         f.g(componentType).p("[]");
     }
 
+    @Override
     public JPackage _package() {
         return owner().rootPackage();
     }
 
+    @Override
     public JClass _extends() {
         return owner().ref(Object.class);
     }
 
+    @Override
     public Iterator<JClass> _implements() {
         return Collections.<JClass>emptyList().iterator();
     }
 
+    @Override
     public boolean isInterface() {
         return false;
     }
 
+    @Override
     public boolean isAbstract() {
         return false;
     }
 
+    @Override
     public JType elementType() {
         return componentType;
     }
 
+    @Override
     public boolean isArray() {
         return true;
     }
@@ -81,6 +92,7 @@ final class JArrayClass extends JClass {
     // Equality is based on value
     //
 
+    @Override
     public boolean equals(Object obj) {
         if(!(obj instanceof JArrayClass))   return false;
         
@@ -90,10 +102,12 @@ final class JArrayClass extends JClass {
         return false;
     }
 
+    @Override
     public int hashCode() {
         return componentType.hashCode();
     }
 
+    @Override
     protected JClass substituteParams(JTypeVar[] variables, List<JClass> bindings) {
         if( componentType.isPrimitive() )
             return this;

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JArrayCompRef.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JArrayCompRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -43,13 +43,16 @@ public final class JArrayCompRef extends JExpressionImpl implements JAssignmentT
         this.index = index;
     }
 
+    @Override
     public void generate(JFormatter f) {
         f.g(array).p('[').g(index).p(']');
     }
 
+    @Override
     public JExpression assign(JExpression rhs) {
 		return JExpr.assign(this,rhs);
     }
+    @Override
     public JExpression assignPlus(JExpression rhs) {
 		return JExpr.assignPlus(this,rhs);
     }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JAssignment.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JAssignment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -31,10 +31,12 @@ public class JAssignment extends JExpressionImpl implements JStatement {
         this.op = op;
     }
 
+    @Override
     public void generate(JFormatter f) {
         f.g(lhs).p(op + '=').g(rhs);
     }
 
+    @Override
     public void state(JFormatter f) {
         f.g(this).p(';').nl();
     }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JAtom.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JAtom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -22,7 +22,14 @@ final class JAtom extends JExpressionImpl {
         this.what = what;
     }
     
+    @Override
     public void generate(JFormatter f) {
         f.p(what);
     }
+
+    @Override
+    public String toString() {
+        return what;
+    }
+
 }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JBlock.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -29,7 +29,7 @@ public final class JBlock implements JGenerable, JStatement {
      * Declarations and statements contained in this block.
      * Either {@link JStatement} or {@link JDeclaration}.
      */
-    private final List<Object> content = new ArrayList<Object>();
+    private final List<Object> content = new ArrayList<>();
 
     /**
      * Whether or not this block must be braced and indented
@@ -390,6 +390,7 @@ public final class JBlock implements JGenerable, JStatement {
      */
     public JStatement directStatement(final String source) {
         JStatement s = new JStatement() {
+            @Override
             public void state(JFormatter f) {
                 f.p(source).nl();
             }
@@ -398,6 +399,7 @@ public final class JBlock implements JGenerable, JStatement {
         return s;
     }
 
+    @Override
     public void generate(JFormatter f) {
         if (bracesRequired)
             f.p('{').nl();
@@ -430,6 +432,7 @@ public final class JBlock implements JGenerable, JStatement {
         return insert(new JForEach( varType, name, collection));
 
     }
+    @Override
     public void state(JFormatter f) {
         f.g(this);
         if (bracesRequired)

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JBreak.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JBreak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -28,6 +28,7 @@ final class JBreak implements JStatement {
         this.label = _label;
     }
 
+    @Override
     public void state(JFormatter f) {
         if( label==null )
             f.p("break;").nl();

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JCase.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -55,6 +55,7 @@ public final class JCase implements JStatement {
         return body;
     }
 
+    @Override
     public void state(JFormatter f) {
         f.i();
         if( !isDefaultCase ) {

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JCast.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JCast.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -41,6 +41,7 @@ public final class JCast extends JExpressionImpl {
         this.object = object;
     }
 
+    @Override
     public void generate(JFormatter f) {
         f.p("((").g(type).p(')').g(object).p(')');
     }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JCatchBlock.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JCatchBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -35,6 +35,7 @@ public class JCatchBlock implements JGenerable {
         return body;
     }
 
+    @Override
     public void generate(JFormatter f) {
         if (var == null)
             var = new JVar(JMods.forVar(JMod.NONE),

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JClass.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -24,8 +24,8 @@ import java.util.List;
  * To be exact, this object represents an "use" of a reference type,
  * not necessarily a declaration of it, which is modeled as {@link JDefinedClass}.
  */
-public abstract class JClass extends JType
-{
+public abstract class JClass extends JType {
+
     protected JClass( JCodeModel _owner ) {
         this._owner = _owner;
     }
@@ -38,6 +38,7 @@ public abstract class JClass extends JType
      *	For example, this method returns "String" for
      *  {@code java.lang.String}.
      */
+    @Override
     abstract public String name();
 	
 	/**
@@ -56,6 +57,7 @@ public abstract class JClass extends JType
 	
     private final JCodeModel _owner;
     /** Gets the JCodeModel object to which this object belongs. */
+    @Override
     public final JCodeModel owner() { return _owner; }
     
     /**
@@ -122,13 +124,16 @@ public abstract class JClass extends JType
      * return {@code this}.
      */
     @Deprecated
+    @Override
     public JClass boxify() { return this; }
 
+    @Override
     public JType unboxify() {
         JPrimitiveType pt = getPrimitiveType();
         return pt==null ? (JType)this : pt;
     }
 
+    @Override
     public JClass erasure() {
         return this;
     }
@@ -216,6 +221,7 @@ public abstract class JClass extends JType
 
 
     private JClass arrayClass;
+    @Override
     public JClass array() {
         if(arrayClass==null)
             arrayClass = new JArrayClass(owner(),this);
@@ -260,7 +266,7 @@ public abstract class JClass extends JType
     }
 
     public JClass narrow( List<? extends JClass> clazz ) {
-        return new JNarrowedClass(this,new ArrayList<JClass>(clazz));
+        return new JNarrowedClass(this,new ArrayList<>(clazz));
     }
 
     /**
@@ -300,6 +306,7 @@ public abstract class JClass extends JType
      */
     protected abstract JClass substituteParams( JTypeVar[] variables, List<JClass> bindings );
     
+    @Override
     public String toString() {
         return this.getClass().getName() + '(' + name() + ')';
     }
@@ -329,6 +336,7 @@ public abstract class JClass extends JType
         return new JFieldRef(this, field);
     }
 
+    @Override
     public void generate(JFormatter f) {
         f.t(this);
     }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JCodeModel.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JCodeModel.java
@@ -554,7 +554,7 @@ public final class JCodeModel {
                 throw new IllegalArgumentException();
             idx++;
 
-            List<JClass> args = new ArrayList<JClass>();
+            List<JClass> args = new ArrayList<>();
 
             while(true) {
                 args.add(parseTypeName());
@@ -593,24 +593,29 @@ public final class JCodeModel {
             assert !_class.isArray();
         }
 
+        @Override
         public String name() {
             return _class.getSimpleName().replace('$','.');
         }
 
+        @Override
         public String fullName() {
             return _class.getName().replace('$','.');
         }
 
+        @Override
         public String binaryName() {
             return _class.getName();
         }
 
+        @Override
         public JClass outer() {
             Class<?> p = _class.getDeclaringClass();
             if(p==null)     return null;
             return ref(p);
         }
 
+        @Override
         public JPackage _package() {
             String name = fullName();
 
@@ -626,6 +631,7 @@ public final class JCodeModel {
                 return JCodeModel.this._package(name.substring(0, idx));
         }
 
+        @Override
         public JClass _extends() {
             Class<?> sp = _class.getSuperclass();
             if (sp == null) {
@@ -636,30 +642,37 @@ public final class JCodeModel {
                 return ref(sp);
         }
 
+        @Override
         public Iterator<JClass> _implements() {
             final Class<?>[] interfaces = _class.getInterfaces();
             return new Iterator<JClass>() {
                 private int idx = 0;
+                @Override
                 public boolean hasNext() {
                     return idx < interfaces.length;
                 }
+                @Override
                 public JClass next() {
                     return JCodeModel.this.ref(interfaces[idx++]);
                 }
+                @Override
                 public void remove() {
                     throw new UnsupportedOperationException();
                 }
             };
         }
 
+        @Override
         public boolean isInterface() {
             return _class.isInterface();
         }
 
+        @Override
         public boolean isAbstract() {
             return Modifier.isAbstract(_class.getModifiers());
         }
 
+        @Override
         public JPrimitiveType getPrimitiveType() {
             Class<?> v = boxToPrimitive.get(_class);
             if(v!=null)
@@ -668,18 +681,22 @@ public final class JCodeModel {
                 return null;
         }
 
+        @Override
         public boolean isArray() {
             return false;
         }
 
+        @Override
         public void declare(JFormatter f) {
         }
 
+        @Override
         public JTypeVar[] typeParams() {
             // TODO: does JDK 1.5 reflection provides these information?
             return super.typeParams();
         }
 
+        @Override
         protected JClass substituteParams(JTypeVar[] variables, List<JClass> bindings) {
             // TODO: does JDK 1.5 reflection provides these information?
             return this;
@@ -697,8 +714,8 @@ public final class JCodeModel {
     public static final Map<Class<?>,Class<?>> boxToPrimitive;
 
     static {
-        Map<Class<?>,Class<?>> m1 = new HashMap<Class<?>,Class<?>>();
-        Map<Class<?>,Class<?>> m2 = new HashMap<Class<?>,Class<?>>();
+        Map<Class<?>,Class<?>> m1 = new HashMap<>();
+        Map<Class<?>,Class<?>> m2 = new HashMap<>();
 
         m1.put(Boolean.class,Boolean.TYPE);
         m1.put(Byte.class,Byte.TYPE);

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JCommentPart.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JCommentPart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -43,6 +43,7 @@ public class JCommentPart extends ArrayList<Object> {
         return this;
     }
 
+        @Override
     public boolean add(Object o) {
         flattenAppend(o);
         return true;

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JConditional.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JConditional.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -67,6 +67,7 @@ public class JConditional implements JStatement {
         return _else()._if(boolExp);
     }
 
+    @Override
     public void state(JFormatter f) {
         if(test==JExpr.TRUE) {
             _then.generateBody(f);

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JContinue.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JContinue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -28,6 +28,7 @@ class JContinue implements JStatement {
         this.label = _label;
     }
 
+    @Override
     public void state(JFormatter f) {
         if( label==null )
             f.p("continue;").nl();

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JDefinedClass.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JDefinedClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -48,10 +48,10 @@ public class JDefinedClass
     private JClass superClass;
 
     /** List of interfaces that this class implements */
-    private final Set<JClass> interfaces = new TreeSet<JClass>();
+    private final Set<JClass> interfaces = new TreeSet<>();
 
     /** Fields keyed by their names. */
-    /*package*/ final Map<String,JFieldVar> fields = new LinkedHashMap<String,JFieldVar>();
+    /*package*/ final Map<String,JFieldVar> fields = new LinkedHashMap<>();
 
     /** Static initializer, if this class has one */
     private JBlock init = null;
@@ -63,10 +63,10 @@ public class JDefinedClass
     private JDocComment jdoc = null;
 
     /** Set of constructors for this class, if any */
-    private final List<JMethod> constructors = new ArrayList<JMethod>();
+    private final List<JMethod> constructors = new ArrayList<>();
 
     /** Set of methods that are members of this class */
-    private final List<JMethod> methods = new ArrayList<JMethod>();
+    private final List<JMethod> methods = new ArrayList<>();
 
     /**
      * Nested classes as a map from name to JDefinedClass.
@@ -125,7 +125,7 @@ public class JDefinedClass
      * In Java, enum constant order is actually significant,
      * because of order ID they get. So let's preserve the order.
      */
-    private final Map<String,JEnumConstant> enumConstantsByName = new LinkedHashMap<String,JEnumConstant>();
+    private final Map<String,JEnumConstant> enumConstantsByName = new LinkedHashMap<>();
 
     /**
      * Annotations on this variable. Lazily created.
@@ -137,6 +137,7 @@ public class JDefinedClass
      * Helper class to implement {@link JGenerifiable}.
      */
     private final JGenerifiableImpl generifiable = new JGenerifiableImpl() {
+        @Override
         protected JCodeModel owner() {
             return JDefinedClass.this.owner();
         }
@@ -258,6 +259,7 @@ public class JDefinedClass
     /**
      * Returns the class extended by this class.
      */
+    @Override
     public JClass _extends() {
         if(superClass==null)
             superClass = owner().ref(Object.class);
@@ -285,6 +287,7 @@ public class JDefinedClass
      * Returns an iterator that walks the nested classes defined in this
      * class.
      */
+    @Override
     public Iterator<JClass> _implements() {
         return interfaces.iterator();
     }
@@ -298,6 +301,7 @@ public class JDefinedClass
      *
      * @return Name of this class
      */
+    @Override
     public String name() {
         return name;
     }
@@ -322,8 +326,18 @@ public class JDefinedClass
     }
 
     /**
+     * Returns set of enum constants keyed by names.
+     *
+     * @return Set of enum constants keyed by names
+     */
+    public Map<String, JEnumConstant> enumConstants() {
+        return Collections.unmodifiableMap(enumConstantsByName);
+    }
+
+    /**
      * Gets the fully qualified name of this class.
      */
+    @Override
     public String fullName() {
         if (outer instanceof JDefinedClass)
             return ((JDefinedClass) outer).fullName() + '.' + name();
@@ -343,10 +357,12 @@ public class JDefinedClass
             return fullName();
     }
 
+    @Override
     public boolean isInterface() {
         return this.classType==ClassType.INTERFACE;
     }
 
+    @Override
     public boolean isAbstract() {
         return mods.isAbstract();
     }
@@ -422,6 +438,7 @@ public class JDefinedClass
      *      When the specified class/interface was already created.
      
      */
+    @Override
     public JDefinedClass _annotationTypeDeclaration(String name) throws JClassAlreadyExistsException {
     	return _class (JMod.PUBLIC,name,ClassType.ANNOTATION_TYPE_DECL);
     }
@@ -436,6 +453,7 @@ public class JDefinedClass
      *      When the specified class/interface was already created.
      
      */
+    @Override
     public JDefinedClass _enum (String name) throws JClassAlreadyExistsException {
     	return _class (JMod.PUBLIC,name,ClassType.ENUM);
     }
@@ -601,12 +619,15 @@ public class JDefinedClass
         return null;
     }
 
+    @Override
     public boolean isClass() {
         return true;
     }
+    @Override
     public boolean isPackage() {
         return false;
     }
+    @Override
     public JPackage getPackage() { return parentContainer().getPackage(); }
 
     /**
@@ -620,6 +641,7 @@ public class JDefinedClass
      *
      * @return Newly generated class
      */
+    @Override
     public JDefinedClass _class(int mods, String name)
         throws JClassAlreadyExistsException {
         return _class(mods, name, ClassType.CLASS);
@@ -631,10 +653,12 @@ public class JDefinedClass
      * @deprecated
      */
     @Deprecated
+    @Override
     public JDefinedClass _class(int mods, String name, boolean isInterface) throws JClassAlreadyExistsException {
     	return _class(mods,name,isInterface?ClassType.INTERFACE:ClassType.CLASS);
     }
 
+    @Override
     public JDefinedClass _class(int mods, String name, ClassType classTypeVal)
         throws JClassAlreadyExistsException {
 
@@ -657,6 +681,7 @@ public class JDefinedClass
     /**
      * Add a new public nested class to this class.
      */
+    @Override
     public JDefinedClass _class(String name)
         throws JClassAlreadyExistsException {
         return _class(JMod.PUBLIC, name);
@@ -673,6 +698,7 @@ public class JDefinedClass
      *
      * @return Newly generated interface
      */
+    @Override
     public JDefinedClass _interface(int mods, String name)
         throws JClassAlreadyExistsException {
         return _class(mods, name, ClassType.INTERFACE);
@@ -681,6 +707,7 @@ public class JDefinedClass
     /**
      * Adds a public interface to this package.
      */
+    @Override
     public JDefinedClass _interface(String name)
         throws JClassAlreadyExistsException {
         return _interface(JMod.PUBLIC, name);
@@ -692,6 +719,7 @@ public class JDefinedClass
      *
      * @return JDocComment containing javadocs for this class
      */
+    @Override
     public JDocComment javadoc() {
         if (jdoc == null)
             jdoc = new JDocComment(owner());
@@ -718,6 +746,7 @@ public class JDefinedClass
      * Returns an iterator that walks the nested classes defined in this
      * class.
      */
+    @Override
     public final Iterator<JDefinedClass> classes() {
         if(classes==null)
             return Collections.<JDefinedClass>emptyList().iterator();
@@ -727,7 +756,7 @@ public class JDefinedClass
 
     private Map<String,JDefinedClass> getClasses() {
         if(classes==null)
-            classes = new TreeMap<String,JDefinedClass>();
+            classes = new TreeMap<>();
         return classes;
     }
 
@@ -750,6 +779,7 @@ public class JDefinedClass
             return null;
     }
 
+    @Override
     public void declare(JFormatter f) {
         if (jdoc != null)
             f.nl().g(jdoc);
@@ -826,23 +856,28 @@ public class JDefinedClass
             directBlock += string;
     }
 
+    @Override
     public final JPackage _package() {
         JClassContainer p = outer;
-        while (!(p instanceof JPackage))
+        while (p != null && !(p instanceof JPackage))
             p = p.parentContainer();
         return (JPackage) p;
     }
 
+    @Override
     public final JClassContainer parentContainer() {
         return outer;
     }
 
+    @Override
     public JTypeVar generify(String name) {
         return generifiable.generify(name);
     }
+    @Override
     public JTypeVar generify(String name, Class<?> bound) {
         return generifiable.generify(name, bound);
     }
+    @Override
     public JTypeVar generify(String name, JClass bound) {
         return generifiable.generify(name, bound);
     }
@@ -851,6 +886,7 @@ public class JDefinedClass
         return generifiable.typeParams();
     }
 
+    @Override
     protected JClass substituteParams(
         JTypeVar[] variables,
         List<JClass> bindings) {
@@ -861,6 +897,7 @@ public class JDefinedClass
      * @param clazz
      *          The annotation class to annotate the class with
      */
+    @Override
     public JAnnotationUse annotate(Class <? extends Annotation> clazz){
         return annotate(owner().ref(clazz));
     }
@@ -869,18 +906,21 @@ public class JDefinedClass
       * @param clazz
       *          The annotation class to annotate the class with
       */
+    @Override
      public JAnnotationUse annotate(JClass clazz){
         if(annotations==null)
-           annotations = new ArrayList<JAnnotationUse>();
+           annotations = new ArrayList<>();
         JAnnotationUse a = new JAnnotationUse(clazz);
         annotations.add(a);
         return a;
     }
 
+    @Override
     public <W extends JAnnotationWriter> W annotate2(Class<W> clazz) {
         return TypedAnnotationWriter.create(clazz,this);
     }
 
+    @Override
     public boolean removeAnnotation(JAnnotationUse annotation) {
         return this.annotations.remove(annotation);
     }
@@ -888,9 +928,10 @@ public class JDefinedClass
     /**
      * {@link JAnnotatable#annotations()}
      */
+    @Override
     public Collection<JAnnotationUse> annotations() {
         if (annotations == null)
-            annotations = new ArrayList<JAnnotationUse>();
+            annotations = new ArrayList<>();
         return Collections.unmodifiableCollection(annotations);
     }
 
@@ -901,5 +942,9 @@ public class JDefinedClass
      */
     public JMods mods() {
         return mods;
+    }
+
+    public JClass superClass() {
+        return superClass;
     }
 }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JDirectClass.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JDirectClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -29,38 +29,46 @@ final class JDirectClass extends JClass {
         this.fullName = fullName;
     }
 
+    @Override
     public String name() {
         int i = fullName.lastIndexOf('.');
         if(i>=0)    return fullName.substring(i+1);
         return fullName;
     }
 
+    @Override
     public String fullName() {
         return fullName;
     }
 
+    @Override
     public JPackage _package() {
         int i = fullName.lastIndexOf('.');
         if(i>=0)    return owner()._package(fullName.substring(0,i));
         else        return owner().rootPackage();
     }
 
+    @Override
     public JClass _extends() {
         return owner().ref(Object.class);
     }
 
+    @Override
     public Iterator<JClass> _implements() {
         return Collections.<JClass>emptyList().iterator();
     }
 
+    @Override
     public boolean isInterface() {
         return false;
     }
 
+    @Override
     public boolean isAbstract() {
         return false;
     }
 
+    @Override
     protected JClass substituteParams(JTypeVar[] variables, List<JClass> bindings) {
         return this;
     }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JDoLoop.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JDoLoop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -39,6 +39,7 @@ public class JDoLoop implements JStatement {
         return body;
     }
 
+    @Override
     public void state(JFormatter f) {
         f.p("do");
         if (body != null)

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JDocComment.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JDocComment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -28,13 +28,13 @@ public class JDocComment extends JCommentPart implements JGenerable {
 	private static final long serialVersionUID = 1L;
 
 	/** list of @param tags */
-    private final Map<String,JCommentPart> atParams = new HashMap<String,JCommentPart>();
+    private final Map<String,JCommentPart> atParams = new HashMap<>();
     
     /** list of xdoclets */
-    private final Map<String,Map<String,String>> atXdoclets = new HashMap<String,Map<String,String>>();
+    private final Map<String,Map<String,String>> atXdoclets = new HashMap<>();
     
     /** list of @throws tags */
-    private final Map<JClass,JCommentPart> atThrows = new HashMap<JClass,JCommentPart>();
+    private final Map<JClass,JCommentPart> atThrows = new HashMap<>();
     
     /**
      * The @return tag part.
@@ -51,6 +51,7 @@ public class JDocComment extends JCommentPart implements JGenerable {
         this.owner = owner;
     }
 
+        @Override
     public JDocComment append(Object o) {
         add(o);
         return this;
@@ -115,7 +116,7 @@ public class JDocComment extends JCommentPart implements JGenerable {
     public Map<String,String> addXdoclet(String name) {
         Map<String,String> p = atXdoclets.get(name);
         if(p==null)
-            atXdoclets.put(name,p=new HashMap<String,String>());
+            atXdoclets.put(name,p=new HashMap<>());
         return p;
     }
 
@@ -125,7 +126,7 @@ public class JDocComment extends JCommentPart implements JGenerable {
     public Map<String,String> addXdoclet(String name, Map<String,String> attributes) {
         Map<String,String> p = atXdoclets.get(name);
         if(p==null)
-            atXdoclets.put(name,p=new HashMap<String,String>());
+            atXdoclets.put(name,p=new HashMap<>());
         p.putAll(attributes);
         return p;
     }
@@ -136,11 +137,12 @@ public class JDocComment extends JCommentPart implements JGenerable {
     public Map<String,String> addXdoclet(String name, String attribute, String value) {
         Map<String,String> p = atXdoclets.get(name);
         if(p==null)
-            atXdoclets.put(name,p=new HashMap<String,String>());
+            atXdoclets.put(name,p=new HashMap<>());
         p.put(attribute, value);
         return p;
     }
 
+        @Override
     public void generate(JFormatter f) {
         // I realized that we can't use StringTokenizer because
         // this will recognize multiple \n as one token.

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JEnumConstant.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JEnumConstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -33,7 +33,7 @@ public final class JEnumConstant extends JExpressionImpl implements JDeclaration
     /**
      * The enum class.
      */
-    private final JDefinedClass type;
+    private final JClass type;
     /**
      * javadoc comments, if any.
      */
@@ -51,7 +51,7 @@ public final class JEnumConstant extends JExpressionImpl implements JDeclaration
      */
     private List<JExpression> args = null;
 
-    JEnumConstant(JDefinedClass type,String name) {
+    JEnumConstant(JClass type,String name) {
         this.name = name;
         this.type = type;
     }
@@ -65,7 +65,7 @@ public final class JEnumConstant extends JExpressionImpl implements JDeclaration
     public JEnumConstant arg(JExpression arg) {
         if(arg==null)   throw new IllegalArgumentException();
         if(args==null)
-            args = new ArrayList<JExpression>();
+            args = new ArrayList<>();
         args.add(arg);
         return this;
     }
@@ -79,11 +79,17 @@ public final class JEnumConstant extends JExpressionImpl implements JDeclaration
     	return this.type.fullName().concat(".").concat(this.name);
     }
 
+    @Override
+    public String toString() {
+        return name;
+    }
+
     /**
      * Creates, if necessary, and returns the enum constant javadoc.
      *
      * @return JDocComment containing javadocs for this constant.
      */
+    @Override
     public JDocComment javadoc() {
         if (jdoc == null)
             jdoc = new JDocComment(type.owner());
@@ -95,9 +101,10 @@ public final class JEnumConstant extends JExpressionImpl implements JDeclaration
      * @param clazz
      *          The annotation class to annotate the field with
      */
+    @Override
     public JAnnotationUse annotate(JClass clazz){
         if(annotations==null)
-           annotations = new ArrayList<JAnnotationUse>();
+           annotations = new ArrayList<>();
         JAnnotationUse a = new JAnnotationUse(clazz);
         annotations.add(a);
         return a;
@@ -109,26 +116,31 @@ public final class JEnumConstant extends JExpressionImpl implements JDeclaration
      * @param clazz
      *          The annotation class to annotate the field with
      */
+    @Override
     public JAnnotationUse annotate(Class <? extends Annotation> clazz){
         return annotate(type.owner().ref(clazz));
     }
 
+    @Override
     public <W extends JAnnotationWriter> W annotate2(Class<W> clazz) {
         return TypedAnnotationWriter.create(clazz,this);
     }
 
+    @Override
     public boolean removeAnnotation(JAnnotationUse annotation) {
         return this.annotations.remove(annotation);
     }
     /**
      * {@link JAnnotatable#annotations()}
      */
+    @Override
     public Collection<JAnnotationUse> annotations() {
         if (annotations == null)
-            annotations = new ArrayList<JAnnotationUse>();
+            annotations = new ArrayList<>();
         return Collections.unmodifiableList(annotations);
     }
 
+    @Override
     public void declare(JFormatter f) {
         if( jdoc != null )
             f.nl().g( jdoc );
@@ -142,7 +154,12 @@ public final class JEnumConstant extends JExpressionImpl implements JDeclaration
         }
     }
 
+    @Override
     public void generate(JFormatter f) {
     	f.t(type).p('.').p(name);
+    }
+
+    JClass type() {
+        return type;
     }
 }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JExpr.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -71,6 +71,7 @@ public abstract class JExpr {
 
     public static JExpression dotclass(final JClass cl) {
         return new JExpressionImpl() {
+                @Override
                 public void generate(JFormatter f) {
                     JClass c;
                     if(cl instanceof JNarrowedClass)
@@ -266,6 +267,7 @@ public abstract class JExpr {
      */
     public static JExpression direct( final String source ) {
         return new JExpressionImpl(){
+            @Override
             public void generate( JFormatter f ) {
                     f.p('(').p(source).p(')');
             }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JExpressionImpl.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JExpressionImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -13,13 +13,13 @@ package com.sun.codemodel;
 /**
  * Provides default implementations for {@link JExpression}.
  */
-public abstract class JExpressionImpl implements JExpression
-{
+public abstract class JExpressionImpl implements JExpression {
     //
     //
     // from JOp
     //
     //
+    @Override
     public final JExpression minus() {
         return JOp.minus(this);
     }
@@ -27,98 +27,122 @@ public abstract class JExpressionImpl implements JExpression
     /**
      * Logical not {@code '!x'}.
      */
+    @Override
     public final JExpression not() {
         return JOp.not(this);
     }
 
+    @Override
     public final JExpression complement() {
         return JOp.complement(this);
     }
 
+    @Override
     public final JExpression incr() {
         return JOp.incr(this);
     }
 
+    @Override
     public final JExpression decr() {
         return JOp.decr(this);
     }
 
+    @Override
     public final JExpression plus(JExpression right) {
         return JOp.plus(this, right);
     }
 
+    @Override
     public final JExpression minus(JExpression right) {
         return JOp.minus(this, right);
     }
 
+    @Override
     public final JExpression mul(JExpression right) {
         return JOp.mul(this, right);
     }
 
+    @Override
     public final JExpression div(JExpression right) {
         return JOp.div(this, right);
     }
 
+    @Override
     public final JExpression mod(JExpression right) {
         return JOp.mod(this, right);
     }
 
+    @Override
     public final JExpression shl(JExpression right) {
         return JOp.shl(this, right);
     }
 
+    @Override
     public final JExpression shr(JExpression right) {
         return JOp.shr(this, right);
     }
 
+    @Override
     public final JExpression shrz(JExpression right) {
         return JOp.shrz(this, right);
     }
 
+    @Override
     public final JExpression band(JExpression right) {
         return JOp.band(this, right);
     }
 
+    @Override
     public final JExpression bor(JExpression right) {
         return JOp.bor(this, right);
     }
 
+    @Override
     public final JExpression cand(JExpression right) {
         return JOp.cand(this, right);
     }
 
+    @Override
     public final JExpression cor(JExpression right) {
         return JOp.cor(this, right);
     }
 
+    @Override
     public final JExpression xor(JExpression right) {
         return JOp.xor(this, right);
     }
 
+    @Override
     public final JExpression lt(JExpression right) {
         return JOp.lt(this, right);
     }
 
+    @Override
     public final JExpression lte(JExpression right) {
         return JOp.lte(this, right);
     }
 
+    @Override
     public final JExpression gt(JExpression right) {
         return JOp.gt(this, right);
     }
 
+    @Override
     public final JExpression gte(JExpression right) {
         return JOp.gte(this, right);
     }
 
+    @Override
     public final JExpression eq(JExpression right) {
         return JOp.eq(this, right);
     }
 
+    @Override
     public final JExpression ne(JExpression right) {
         return JOp.ne(this, right);
     }
 
+    @Override
     public final JExpression _instanceof(JType right) {
         return JOp._instanceof(this, right);
     }
@@ -128,22 +152,27 @@ public abstract class JExpressionImpl implements JExpression
     // from JExpr
     //
     //
+    @Override
     public final JInvocation invoke(JMethod method) {
         return JExpr.invoke(this, method);
     }
 
+    @Override
     public final JInvocation invoke(String method) {
         return JExpr.invoke(this, method);
     }
 
+    @Override
     public final JFieldRef ref(JVar field) {
         return JExpr.ref(this, field);
     }
 
+    @Override
     public final JFieldRef ref(String field) {
         return JExpr.ref(this, field);
     }
 
+    @Override
     public final JArrayCompRef component(JExpression index) {
         return JExpr.component(this, index);
     }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JFieldRef.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JFieldRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -80,6 +80,7 @@ public class JFieldRef extends JExpressionImpl implements JAssignmentTarget {
         this.var = var;
     }
 
+    @Override
     public void generate(JFormatter f) {
         String name = this.name;
         if(name==null)  name=var.name();
@@ -95,9 +96,11 @@ public class JFieldRef extends JExpressionImpl implements JAssignmentTarget {
         }
     }
 
+    @Override
     public JExpression assign(JExpression rhs) {
         return JExpr.assign(this, rhs);
     }
+    @Override
     public JExpression assignPlus(JExpression rhs) {
         return JExpr.assignPlus(this, rhs);
     }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JFieldVar.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JFieldVar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -60,12 +60,14 @@ public class JFieldVar extends JVar implements JDocCommentable {
      *
      * @return JDocComment containing javadocs for this class
      */
+    @Override
     public JDocComment javadoc() {
         if( jdoc == null ) 
             jdoc = new JDocComment(owner.owner());
         return jdoc;
     }
 
+    @Override
     public void declare(JFormatter f) {
         if( jdoc != null )
             f.g( jdoc );

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JForEach.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JForEach.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -47,6 +47,7 @@ public final class JForEach implements JStatement {
 		return body;
 	}
 
+        @Override
 	public void state(JFormatter f) {
 		f.p("for (");
 		f.g(type).id(var).p(": ").g(collection);

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JForLoop.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JForLoop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -20,9 +20,9 @@ import java.util.List;
 
 public class JForLoop implements JStatement {
     
-    private List<Object> inits = new ArrayList<Object>();
+    private List<Object> inits = new ArrayList<>();
     private JExpression test = null;
-    private List<JExpression> updates = new ArrayList<JExpression>();
+    private List<JExpression> updates = new ArrayList<>();
     private JBlock body = null;
     
     public JVar init(int mods, JType type, String var, JExpression e) {
@@ -52,6 +52,7 @@ public class JForLoop implements JStatement {
         return body;
     }
     
+    @Override
     public void state(JFormatter f) {
         f.p("for (");
         boolean first = true;

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JFormatter.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JFormatter.java
@@ -101,9 +101,9 @@ public final class JFormatter {
     public JFormatter(PrintWriter s, String space, Map<String, String> classNameReplacer) {
         pw = s;
         indentSpace = space;
-        collectedReferences = new HashMap<String,ReferenceList>();
+        collectedReferences = new HashMap<>();
         //ids = new HashSet<String>();
-        importedClasses = new HashSet<JClass>();
+        importedClasses = new HashSet<>();
         this.classNameReplacer = classNameReplacer;
     }
 
@@ -513,7 +513,7 @@ public final class JFormatter {
      * @author Ryan.Shoemaker@Sun.COM
      */
     final class ReferenceList {
-        private final ArrayList<JClass> classes = new ArrayList<JClass>();
+        private final ArrayList<JClass> classes = new ArrayList<>();
 
         /** true if this name is used as an identifier (like a variable name.) **/
         private boolean id;

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JGenerifiableImpl.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JGenerifiableImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -26,6 +26,7 @@ abstract class JGenerifiableImpl implements JGenerifiable, JDeclaration {
     
     protected abstract JCodeModel owner();
     
+    @Override
     public void declare( JFormatter f ) {
         if(typeVariables!=null) {
             f.p('<');
@@ -38,22 +39,26 @@ abstract class JGenerifiableImpl implements JGenerifiable, JDeclaration {
     }
 
 
+    @Override
     public JTypeVar generify(String name) {
         JTypeVar v = new JTypeVar(owner(),name);
         if(typeVariables==null)
-            typeVariables = new ArrayList<JTypeVar>(3);
+            typeVariables = new ArrayList<>(3);
         typeVariables.add(v);
         return v;
     }
 
+    @Override
     public JTypeVar generify(String name, Class<?> bound) {
         return generify(name,owner().ref(bound));
     }
 
+    @Override
     public JTypeVar generify(String name, JClass bound) {
         return generify(name).bound(bound);
     }
     
+    @Override
     public JTypeVar[] typeParams() {
         if(typeVariables==null)
             return JTypeVar.EMPTY_ARRAY;

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JInvocation.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JInvocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -40,7 +40,7 @@ public final class JInvocation extends JExpressionImpl implements JStatement {
     /**
      * List of argument expressions for this method invocation
      */
-    private List<JExpression> args = new ArrayList<JExpression>();
+    private List<JExpression> args = new ArrayList<>();
 
     /**
      * If isConstructor==true, this field keeps the type to be created.
@@ -134,6 +134,7 @@ public final class JInvocation extends JExpressionImpl implements JStatement {
 		return args.toArray(new JExpression[args.size()]);
 	}
 
+    @Override
     public void generate(JFormatter f) {
         if (isConstructor && type.isArray()) {
             // [RESULT] new T[]{arg1,arg2,arg3,...};
@@ -164,6 +165,7 @@ public final class JInvocation extends JExpressionImpl implements JStatement {
         }
     }
 
+    @Override
     public void state(JFormatter f) {
         f.g(this).p(';').nl();
     }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JLabel.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JLabel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -30,6 +30,7 @@ public class JLabel implements JStatement {
         this.label = _label;
     }
 
+    @Override
     public void state(JFormatter f) {
         f.p(label+':').nl();
     }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JMethod.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -7,7 +7,6 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-
 package com.sun.codemodel;
 
 import java.lang.annotation.Annotation;
@@ -25,214 +24,202 @@ import com.sun.codemodel.util.ClassNameComparator;
  */
 public class JMethod extends JGenerifiableImpl implements JDeclaration, JAnnotatable, JDocCommentable {
 
-	/**
-	 * Modifiers for this method
-	 */
-	private JMods mods;
+    /**
+     * Modifiers for this method
+     */
+    private JMods mods;
 
-	/**
-	 * Return type for this method
-	 */
-	private JType type = null;
+    /**
+     * Return type for this method
+     */
+    private JType type = null;
 
-	/**
-	 * Name of this method
-	 */
-	private String name = null;
+    /**
+     * Name of this method
+     */
+    private String name = null;
 
-	/**
-	 * List of parameters for this method's declaration
-	 */
-	private final List<JVar> params = new ArrayList<JVar>();
+    /**
+     * List of parameters for this method's declaration
+     */
+    private final List<JVar> params = new ArrayList<>();
 
-	/**
-	 * Set of exceptions that this method may throw.
-     * A set instance lazily created.
-	 */
-	private Set<JClass> _throws;
+    /**
+     * Set of exceptions that this method may throw. A set instance lazily
+     * created.
+     */
+    private Set<JClass> _throws;
 
-	/**
-	 * JBlock of statements that makes up the body this method
-	 */
-	private JBlock body = null;
+    /**
+     * JBlock of statements that makes up the body this method
+     */
+    private JBlock body = null;
 
-	private JDefinedClass outer;
+    private JDefinedClass outer;
 
-	/**
-	 * javadoc comments for this JMethod
-	 */
-	private JDocComment jdoc = null;
+    /**
+     * javadoc comments for this JMethod
+     */
+    private JDocComment jdoc = null;
 
-	/**
-	 * Variable parameter for this method's varargs declaration
-	 * introduced in J2SE 1.5
-	 */
-	private JVar varParam = null;
+    /**
+     * Variable parameter for this method's varargs declaration introduced in
+     * J2SE 1.5
+     */
+    private JVar varParam = null;
 
     /**
      * Annotations on this variable. Lazily created.
      */
     private List<JAnnotationUse> annotations = null;
 
+    private boolean isConstructor() {
+        return type == null;
+    }
 
-	private boolean isConstructor() {
-		return type == null;
-	}
-    
-    /** To set the default value for the
-     *  annotation member
+    /**
+     * To set the default value for the annotation member
      */
     private JExpression defaultValue = null;
-    
 
-	/**
-	 * JMethod constructor
-	 *
-	 * @param mods
-	 *        Modifiers for this method's declaration
-	 *
-	 * @param type
-	 *        Return type for the method
-	 *
-	 * @param name
-	 *        Name of this method
-	 */
-	JMethod(JDefinedClass outer, int mods, JType type, String name) {
-		this.mods = JMods.forMethod(mods);
-		this.type = type;
-		this.name = name;
-		this.outer = outer;
-	}
+    /**
+     * JMethod constructor
+     *
+     * @param mods Modifiers for this method's declaration
+     *
+     * @param type Return type for the method
+     *
+     * @param name Name of this method
+     */
+    JMethod(JDefinedClass outer, int mods, JType type, String name) {
+        this.mods = JMods.forMethod(mods);
+        this.type = type;
+        this.name = name;
+        this.outer = outer;
+    }
 
-	/**
-	 * Constructor constructor
-	 *
-	 * @param mods
-	 *        Modifiers for this constructor's declaration
-	 *
-	 * @param _class
-	 *        JClass containing this constructor
-	 */
-	JMethod(int mods, JDefinedClass _class) {
-		this.mods = JMods.forMethod(mods);
-		this.type = null;
-		this.name = _class.name();
-		this.outer = _class;
-	}
-    
+    /**
+     * Constructor constructor
+     *
+     * @param mods Modifiers for this constructor's declaration
+     *
+     * @param _class JClass containing this constructor
+     */
+    JMethod(int mods, JDefinedClass _class) {
+        this.mods = JMods.forMethod(mods);
+        this.type = null;
+        this.name = _class.name();
+        this.outer = _class;
+    }
+
     private Set<JClass> getThrows() {
-        if(_throws==null)
-            _throws = new TreeSet<JClass>(ClassNameComparator.theInstance);
+        if (_throws == null) {
+            _throws = new TreeSet<>(ClassNameComparator.theInstance);
+        }
         return _throws;
     }
 
-	/**
-	 * Add an exception to the list of exceptions that this
-	 * method may throw.
-	 *
-	 * @param exception
-	 *        Name of an exception that this method may throw
-	 */
-	public JMethod _throws(JClass exception) {
+    /**
+     * Add an exception to the list of exceptions that this method may throw.
+     *
+     * @param exception Name of an exception that this method may throw
+     */
+    public JMethod _throws(JClass exception) {
         getThrows().add(exception);
-		return this;
-	}
+        return this;
+    }
 
-	public JMethod _throws(Class<? extends Throwable> exception) {
-		return _throws(outer.owner().ref(exception));
-	}
-
-	/**
-	 * Returns the list of variable of this method.
-	 *
-	 * @return List of parameters of this method. This list is not modifiable.
-	 */
-	public List<JVar> params() {
-		return Collections.<JVar>unmodifiableList(params);
-	}
-	
-	/**
-	 * Add the specified variable to the list of parameters
-	 * for this method signature.
-	 *
-	 * @param type
-	 *        JType of the parameter being added
-	 *
-	 * @param name
-	 *        Name of the parameter being added
-	 *
-	 * @return New parameter variable
-	 */
-	public JVar param(int mods, JType type, String name) {
-		JVar v = new JVar(JMods.forVar(mods), type, name, null);
-		params.add(v);
-		return v;
-	}
-
-	public JVar param(JType type, String name) {
-		return param(JMod.NONE, type, name);
-	}
-
-	public JVar param(int mods, Class<?> type, String name) {
-		return param(mods, outer.owner()._ref(type), name);
-	}
-
-	public JVar param(Class<?> type, String name) {
-		return param(outer.owner()._ref(type), name);
-	}
-
-	/**
-	 * @see #varParam(JType, String)
-	 */
-	public JVar varParam(Class<?> type, String name) {
-        return varParam(outer.owner()._ref(type),name);
+    public JMethod _throws(Class<? extends Throwable> exception) {
+        return _throws(outer.owner().ref(exception));
     }
 
     /**
-     * Add the specified variable argument to the list of parameters
-     * for this method signature.
+     * Returns the list of variable of this method.
      *
-     * @param type
-     *      Type of the parameter being added.
+     * @return List of parameters of this method. This list is not modifiable.
+     */
+    public List<JVar> params() {
+        return Collections.<JVar>unmodifiableList(params);
+    }
+
+    /**
+     * Add the specified variable to the list of parameters for this method
+     * signature.
      *
-     * @param name
-     *        Name of the parameter being added
+     * @param type JType of the parameter being added
+     *
+     * @param name Name of the parameter being added
+     *
+     * @return New parameter variable
+     */
+    public JVar param(int mods, JType type, String name) {
+        JVar v = new JVar(JMods.forVar(mods), type, name, null);
+        params.add(v);
+        return v;
+    }
+
+    public JVar param(JType type, String name) {
+        return param(JMod.NONE, type, name);
+    }
+
+    public JVar param(int mods, Class<?> type, String name) {
+        return param(mods, outer.owner()._ref(type), name);
+    }
+
+    public JVar param(Class<?> type, String name) {
+        return param(outer.owner()._ref(type), name);
+    }
+
+    /**
+     * @see #varParam(JType, String)
+     */
+    public JVar varParam(Class<?> type, String name) {
+        return varParam(outer.owner()._ref(type), name);
+    }
+
+    /**
+     * Add the specified variable argument to the list of parameters for this
+     * method signature.
+     *
+     * @param type Type of the parameter being added.
+     *
+     * @param name Name of the parameter being added
      *
      * @return the variable parameter
-     * 
-     * @throws IllegalStateException
-     *      If this method is called twice.
-     *      varargs in J2SE 1.5 can appear only once in the 
-     *      method signature.
+     *
+     * @throws IllegalStateException If this method is called twice. varargs in
+     * J2SE 1.5 can appear only once in the method signature.
      */
     public JVar varParam(JType type, String name) {
-		if (!hasVarArgs()) {
+        if (!hasVarArgs()) {
 
-            varParam =
-				new JVar(
-					JMods.forVar(JMod.NONE),
-					type.array(),
-					name,
-					null);
-			return varParam;
-		} else {
-			throw new IllegalStateException(
-				"Cannot have two varargs in a method,\n"
-					+ "Check if varParam method of JMethod is"
-					+ " invoked more than once");
+            varParam
+                    = new JVar(
+                            JMods.forVar(JMod.NONE),
+                            type.array(),
+                            name,
+                            null);
+            return varParam;
+        } else {
+            throw new IllegalStateException(
+                    "Cannot have two varargs in a method,\n"
+                    + "Check if varParam method of JMethod is"
+                    + " invoked more than once");
 
-		}
+        }
 
-	}
+    }
 
     /**
      * Adds an annotation to this variable.
-     * @param clazz
-     *          The annotation class to annotate the field with
+     *
+     * @param clazz The annotation class to annotate the field with
      */
-    public JAnnotationUse annotate(JClass clazz){
-        if(annotations==null)
-           annotations = new ArrayList<JAnnotationUse>();
+    @Override
+    public JAnnotationUse annotate(JClass clazz) {
+        if (annotations == null) {
+            annotations = new ArrayList<>();
+        }
         JAnnotationUse a = new JAnnotationUse(clazz);
         annotations.add(a);
         return a;
@@ -241,38 +228,41 @@ public class JMethod extends JGenerifiableImpl implements JDeclaration, JAnnotat
     /**
      * Adds an annotation to this variable.
      *
-     * @param clazz
-     *          The annotation class to annotate the field with
+     * @param clazz The annotation class to annotate the field with
      */
-    public JAnnotationUse annotate(Class <? extends Annotation> clazz){
+    @Override
+    public JAnnotationUse annotate(Class<? extends Annotation> clazz) {
         return annotate(owner().ref(clazz));
     }
 
+    @Override
     public <W extends JAnnotationWriter> W annotate2(Class<W> clazz) {
-        return TypedAnnotationWriter.create(clazz,this);
+        return TypedAnnotationWriter.create(clazz, this);
     }
 
+    @Override
     public boolean removeAnnotation(JAnnotationUse annotation) {
         return this.annotations.remove(annotation);
     }
 
+    @Override
     public Collection<JAnnotationUse> annotations() {
-        if (annotations == null)
-            annotations = new ArrayList<JAnnotationUse>();
+        if (annotations == null) {
+            annotations = new ArrayList<>();
+        }
         return Collections.unmodifiableList(annotations);
     }
 
     /**
-	 * Check if there are any varargs declared
-	 * for this method signature.
-	 */
-	public boolean hasVarArgs() {
-		return this.varParam!=null;
-	}
+     * Check if there are any varargs declared for this method signature.
+     */
+    public boolean hasVarArgs() {
+        return this.varParam != null;
+    }
 
-	public String name() {
-		return name;
-	}
+    public String name() {
+        return name;
+    }
 
     /**
      * Changes the name of the method.
@@ -282,11 +272,11 @@ public class JMethod extends JGenerifiableImpl implements JDeclaration, JAnnotat
     }
 
     /**
-	 * Returns the return type.
-	 */
-	public JType type() {
-		return type;
-	}
+     * Returns the return type.
+     */
+    public JType type() {
+        return type;
+    }
 
     /**
      * Overrides the return type.
@@ -296,169 +286,175 @@ public class JMethod extends JGenerifiableImpl implements JDeclaration, JAnnotat
     }
 
     /**
-	 * Returns all the parameter types in an array.
-	 * @return
-	 *      If there's no parameter, an empty array will be returned.
-	 */
-	public JType[] listParamTypes() {
-		JType[] r = new JType[params.size()];
-		for (int i = 0; i < r.length; i++)
-			r[i] = params.get(i).type();
-		return r;
-	}
+     * Returns all the parameter types in an array.
+     *
+     * @return If there's no parameter, an empty array will be returned.
+     */
+    public JType[] listParamTypes() {
+        JType[] r = new JType[params.size()];
+        for (int i = 0; i < r.length; i++) {
+            r[i] = params.get(i).type();
+        }
+        return r;
+    }
 
-	/**
-	 * Returns  the varags parameter type.
-	 * @return
-	 * If there's no vararg parameter type, null will be returned.
-	 */
-	public JType listVarParamType() {
-		if (varParam != null)
-			return varParam.type();
-		else
-			return null;
-	}
+    /**
+     * Returns the varags parameter type.
+     *
+     * @return If there's no vararg parameter type, null will be returned.
+     */
+    public JType listVarParamType() {
+        if (varParam != null) {
+            return varParam.type();
+        } else {
+            return null;
+        }
+    }
 
-	/**
-	 * Returns all the parameters in an array.
-	 * @return
-	 *      If there's no parameter, an empty array will be returned.
-	 */
-	public JVar[] listParams() {
-		return params.toArray(new JVar[params.size()]);
-	}
+    /**
+     * Returns all the parameters in an array.
+     *
+     * @return If there's no parameter, an empty array will be returned.
+     */
+    public JVar[] listParams() {
+        return params.toArray(new JVar[params.size()]);
+    }
 
-	/**
-	 * Returns the variable parameter
-	 * @return
-	 *      If there's no parameter, null will be returned.
-	 */
-	public JVar listVarParam() {
-		return varParam;
-	}
+    /**
+     * Returns the variable parameter
+     *
+     * @return If there's no parameter, null will be returned.
+     */
+    public JVar listVarParam() {
+        return varParam;
+    }
 
-	/**
-	 * Returns true if the method has the specified signature.
-	 */
-	public boolean hasSignature(JType[] argTypes) {
-		JVar[] p = listParams();
-		if (p.length != argTypes.length)
-			return false;
+    /**
+     * Returns true if the method has the specified signature.
+     */
+    public boolean hasSignature(JType[] argTypes) {
+        JVar[] p = listParams();
+        if (p.length != argTypes.length) {
+            return false;
+        }
 
-		for (int i = 0; i < p.length; i++)
-			if (!p[i].type().equals(argTypes[i]))
-				return false;
+        for (int i = 0; i < p.length; i++) {
+            if (!p[i].type().equals(argTypes[i])) {
+                return false;
+            }
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	/**
-	 * Get the block that makes up body of this method
-	 *
-	 * @return Body of method
-	 */
-	public JBlock body() {
-		if (body == null)
-			body = new JBlock();
-		return body;
-	}
-    
+    /**
+     * Get the block that makes up body of this method
+     *
+     * @return Body of method
+     */
+    public JBlock body() {
+        if (body == null) {
+            body = new JBlock();
+        }
+        return body;
+    }
+
     /**
      * Specify the default value for this annotation member
-     * @param value 
-     *           Default value for the annotation member
-     * 
+     *
+     * @param value Default value for the annotation member
+     *
      */
-    public void declareDefaultValue(JExpression value){
+    public void declareDefaultValue(JExpression value) {
         this.defaultValue = value;
     }
 
-	/**
-	 * Creates, if necessary, and returns the class javadoc for this
-	 * JDefinedClass
-	 *
-	 * @return JDocComment containing javadocs for this class
-	 */
-	public JDocComment javadoc() {
-		if (jdoc == null)
-			jdoc = new JDocComment(owner());
-		return jdoc;
-	}
+    /**
+     * Creates, if necessary, and returns the class javadoc for this
+     * JDefinedClass
+     *
+     * @return JDocComment containing javadocs for this class
+     */
+    @Override
+    public JDocComment javadoc() {
+        if (jdoc == null) {
+            jdoc = new JDocComment(owner());
+        }
+        return jdoc;
+    }
 
-	public void declare(JFormatter f) {
-		if (jdoc != null)
-			f.g(jdoc);
+    @Override
+    public void declare(JFormatter f) {
+        if (jdoc != null) {
+            f.g(jdoc);
+        }
 
-        if (annotations != null){
-            for (JAnnotationUse a : annotations)
+        if (annotations != null) {
+            for (JAnnotationUse a : annotations) {
                 f.g(a).nl();
+            }
         }
 
         f.g(mods);
-        
-        // declare the generics parameters
-		super.declare(f);
 
-		if (!isConstructor())
-			f.g(type);
-		f.id(name).p('(').i();
+        // declare the generics parameters
+        super.declare(f);
+
+        if (!isConstructor()) {
+            f.g(type);
+        }
+        f.id(name).p('(').i();
         // when parameters are printed in new lines, we want them to be indented.
         // there's a good chance no newlines happen, too, but just in case it does.
-		boolean first = true;
+        boolean first = true;
         for (JVar var : params) {
-            if (!first)
+            if (!first) {
                 f.p(',');
-            if(var.isAnnotated())
+            }
+            if (var.isAnnotated()) {
                 f.nl();
+            }
             f.b(var);
             first = false;
         }
-		if (hasVarArgs()) {
-			if (!first)
-				f.p(',');
-			f.g(varParam.type().elementType());
-			f.p("... ");
-			f.id(varParam.name());
-		}
+        if (hasVarArgs()) {
+            if (!first) {
+                f.p(',');
+            }
+            f.g(varParam.type().elementType());
+            f.p("... ");
+            f.id(varParam.name());
+        }
 
-		f.o().p(')');
-		if (_throws!=null && !_throws.isEmpty()) {
-			f.nl().i().p("throws").g(_throws).nl().o();
-		}
-        
+        f.o().p(')');
+        if (_throws != null && !_throws.isEmpty()) {
+            f.nl().i().p("throws").g(_throws).nl().o();
+        }
+
         if (defaultValue != null) {
             f.p("default ");
             f.g(defaultValue);
         }
-		if (body != null) {
-			f.s(body);
-		} else if (
-			!outer.isInterface() && !outer.isAnnotationTypeDeclaration() && !mods.isAbstract() && !mods.isNative()) {
-			// Print an empty body for non-native, non-abstract methods
-			f.s(new JBlock());
-		} else {
-			f.p(';').nl();
-		}
-	}
+        if (body != null) {
+            f.s(body);
+        } else if (!outer.isInterface() && !outer.isAnnotationTypeDeclaration() && !mods.isAbstract() && !mods.isNative()) {
+            // Print an empty body for non-native, non-abstract methods
+            f.s(new JBlock());
+        } else {
+            f.p(';').nl();
+        }
+    }
 
     /**
-     * @return
-     *      the current modifiers of this method.
-     *      Always return non-null valid object.
+     * @return the current modifiers of this method. Always return non-null
+     * valid object.
      */
     public JMods mods() {
         return mods;
     }
 
-    /**
-     * @deprecated use {@link #mods()} 
-     */
-    @Deprecated
-    public JMods getMods() {
-		return mods;
-	}
-
-	protected JCodeModel owner() {
-		return outer.owner();
-	}
+    @Override
+    protected JCodeModel owner() {
+        return outer.owner();
+    }
 }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JMods.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JMods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -120,6 +120,7 @@ public class JMods implements JGenerable {
         mods = (mods & ~bit) | (newValue ? bit : 0);
     }
 
+    @Override
     public void generate(JFormatter f) {
         if ((mods & JMod.PUBLIC) != 0)        f.p("public");
         if ((mods & JMod.PROTECTED) != 0)     f.p("protected");

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JNarrowedClass.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JNarrowedClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -47,18 +47,19 @@ class JNarrowedClass extends JClass {
 
     @Override
     public JClass narrow( JClass clazz ) {
-        List<JClass> newArgs = new ArrayList<JClass>(args);
+        List<JClass> newArgs = new ArrayList<>(args);
         newArgs.add(clazz);
         return new JNarrowedClass(basis,newArgs);
     }
 
     @Override
     public JClass narrow( JClass... clazz ) {
-        List<JClass> newArgs = new ArrayList<JClass>(args);
+        List<JClass> newArgs = new ArrayList<>(args);
         newArgs.addAll(Arrays.asList(clazz));
         return new JNarrowedClass(basis,newArgs);
     }
 
+    @Override
     public String name() {
         StringBuilder buf = new StringBuilder();
         buf.append(basis.name());
@@ -75,6 +76,7 @@ class JNarrowedClass extends JClass {
         return buf.toString();
     }
     
+    @Override
     public String fullName() {
         StringBuilder buf = new StringBuilder();
         buf.append(basis.fullName());
@@ -128,25 +130,31 @@ class JNarrowedClass extends JClass {
         f.p("{@code >}");
     }
 
+    @Override
     public JPackage _package() {
         return basis._package();
     }
 
+    @Override
     public JClass _extends() {
         JClass base = basis._extends();
         if(base==null)  return base;
         return base.substituteParams(basis.typeParams(),args);
     }
 
+    @Override
     public Iterator<JClass> _implements() {
         return new Iterator<JClass>() {
             private final Iterator<JClass> core = basis._implements();
+            @Override
             public void remove() {
                 core.remove();
             }
+            @Override
             public JClass next() {
                 return core.next().substituteParams(basis.typeParams(),args);
             }
+            @Override
             public boolean hasNext() {
                 return core.hasNext();
             }
@@ -158,10 +166,12 @@ class JNarrowedClass extends JClass {
         return basis;
     }
 
+    @Override
     public boolean isInterface() {
         return basis.isInterface();
     }
 
+    @Override
     public boolean isAbstract() {
         return basis.isAbstract();
     }
@@ -187,11 +197,12 @@ class JNarrowedClass extends JClass {
         return fullName().hashCode();
     }
 
+    @Override
     protected JClass substituteParams(JTypeVar[] variables, List<JClass> bindings) {
         JClass b = basis.substituteParams(variables,bindings);
         boolean different = b!=basis;
         
-        List<JClass> clazz = new ArrayList<JClass>(args.size());
+        List<JClass> clazz = new ArrayList<>(args.size());
         for( int i=0; i<clazz.size(); i++ ) {
             JClass c = args.get(i).substituteParams(variables,bindings);
             clazz.set(i,c);

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JNullType.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JNullType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -29,20 +29,28 @@ public final class JNullType extends JClass {
         super(_owner);
     }
 
+    @Override
     public String name() { return "null"; }
+    @Override
     public String fullName() { return "null"; }
 
+    @Override
     public JPackage _package() { return owner()._package(""); }
 
+    @Override
     public JClass _extends() { return null; }
 
+    @Override
     public Iterator<JClass> _implements() {
         return Collections.<JClass>emptyList().iterator();
     }
 
+    @Override
     public boolean isInterface() { return false; }
+    @Override
     public boolean isAbstract() { return false; }
 
+    @Override
     protected JClass substituteParams(JTypeVar[] variables, List<JClass> bindings) {
         return this;
     }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JOp.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -48,6 +48,7 @@ abstract public class JOp {
             opFirst = false;
         }
 
+        @Override
         public void generate(JFormatter f) {
             if (opFirst)
                 f.p('(').p(op).g(e).p(')');
@@ -80,6 +81,7 @@ abstract public class JOp {
             super(e, op);
         }
 
+        @Override
         public void generate(JFormatter f) {
             if (opFirst)
                 f.p(op).g(e);
@@ -112,6 +114,7 @@ abstract public class JOp {
             this.right = right;
         }
 
+        @Override
         public void generate(JFormatter f) {
             f.p('(').g(left).p(op).g(right).p(')');
         }
@@ -225,6 +228,7 @@ abstract public class JOp {
             this.e3 = e3;
         }
 
+        @Override
         public void generate(JFormatter f) {
             f.p('(').g(e1).p(op1).g(e2).p(op2).g(e3).p(')');
         }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JPrimitiveType.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JPrimitiveType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -33,21 +33,26 @@ public final class JPrimitiveType extends JType {
         this.wrapperClass = owner.ref(wrapper);
     }
 
+    @Override
     public JCodeModel owner() { return owner; }
 
+    @Override
     public String fullName() {
         return typeName;
     }
         
+    @Override
     public String name() {
         return fullName();
     }
 
+    @Override
     public boolean isPrimitive() {
         return true;
     }
 
     private JClass arrayClass;
+    @Override
     public JClass array() {
         if(arrayClass==null)
             arrayClass = new JArrayClass(owner,this);
@@ -59,6 +64,7 @@ public final class JPrimitiveType extends JType {
      * For example, this method returns a reference to java.lang.Integer
      * if this object represents int.
      */
+    @Override
     public JClass boxify() {
         return wrapperClass;
     }
@@ -69,6 +75,7 @@ public final class JPrimitiveType extends JType {
      * return {@code this}.
      */
     @Deprecated
+    @Override
     public JType unboxify() {
         return this;
     }
@@ -104,6 +111,7 @@ public final class JPrimitiveType extends JType {
         return exp.invoke(typeName+"Value");
     }
 
+    @Override
     public void generate(JFormatter f) {
         f.p(typeName);
     }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JReturn.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JReturn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -31,6 +31,7 @@ class JReturn implements JStatement {
        this.expr = expr;
     }
 
+    @Override
     public void state(JFormatter f) {
         f.p("return ");
         if (expr != null) f.g(expr);

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JStringLiteral.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JStringLiteral.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -19,7 +19,6 @@ package com.sun.codemodel;
 public class JStringLiteral extends JExpressionImpl {
 
     public final String str;
-    
 
     JStringLiteral(String what) {
         this.str = what;
@@ -27,7 +26,14 @@ public class JStringLiteral extends JExpressionImpl {
     }
    
     
+    @Override
     public void generate(JFormatter f) {
-    	f.p(JExpr.quotify('"', str));
+        f.p(JExpr.quotify('"', str));
     }
+
+    @Override
+    public String toString() {
+        return str;
+    }
+
 }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JSwitch.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JSwitch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -27,7 +27,7 @@ public final class JSwitch implements JStatement {
     /**
      * vector of JCases.
      */
-    private List<JCase> cases = new ArrayList<JCase>();
+    private List<JCase> cases = new ArrayList<>();
     
     /**
      * a single default case
@@ -59,6 +59,7 @@ public final class JSwitch implements JStatement {
         return defaultCase;
     }
     
+    @Override
     public void state(JFormatter f) {
         if (JOp.hasTopOp(test)) {
             f.p("switch ").g(test).p(" {").nl();

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JThrow.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JThrow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -32,6 +32,7 @@ class JThrow implements JStatement {
        this.expr = expr;
     }
 
+    @Override
     public void state(JFormatter f) {
         f.p("throw");
         f.g(expr);

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JTryBlock.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JTryBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -21,7 +21,7 @@ import java.util.List;
 public class JTryBlock implements JStatement {
 
     private JBlock body = new JBlock();
-    private List<JCatchBlock> catches = new ArrayList<JCatchBlock>();
+    private List<JCatchBlock> catches = new ArrayList<>();
     private JBlock _finally = null;
 
     JTryBlock() {
@@ -42,6 +42,7 @@ public class JTryBlock implements JStatement {
         return _finally;
     }
 
+    @Override
     public void state(JFormatter f) {
         f.p("try").g(body);
         for (JCatchBlock cb : catches)

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JType.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -140,6 +140,7 @@ public abstract class JType implements JGenerable, Comparable<JType> {
         throw new IllegalArgumentException("Not an array type");
     }
 
+    @Override
     public String toString() {
         return this.getClass().getName()
                 + '(' + fullName() + ')';
@@ -152,6 +153,7 @@ public abstract class JType implements JGenerable, Comparable<JType> {
      * This method is used to sort generated import statments in a
      * conventional way for readability.
      */
+    @Override
     public int compareTo(JType o) {
         final String rhs = o.fullName();
         boolean p = fullName().startsWith("java");

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JTypeVar.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JTypeVar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -31,14 +31,17 @@ public final class JTypeVar extends JClass implements JDeclaration {
         this.name = _name;
     }
     
+    @Override
     public String name() {
         return name;
     }
 
+    @Override
     public String fullName() {
         return name;
     }
 
+    @Override
     public JPackage _package() {
         return null;
     }
@@ -56,11 +59,19 @@ public final class JTypeVar extends JClass implements JDeclaration {
     }
 
     /**
+     * @return bound of this variable
+     */
+    public JClass bound() {
+        return bound;
+    }
+
+    /**
      * Returns the class bound of this variable.
      * 
      * <p>
      * If no bound is given, this method returns {@link Object}.
      */
+    @Override
     public JClass _extends() {
         if(bound!=null)
             return bound;
@@ -71,14 +82,17 @@ public final class JTypeVar extends JClass implements JDeclaration {
     /**
      * Returns the interface bounds of this variable.
      */
+    @Override
     public Iterator<JClass> _implements() {
         return bound._implements();
     }
 
+    @Override
     public boolean isInterface() {
         return false;
     }
 
+    @Override
     public boolean isAbstract() {
         return false;
     }
@@ -86,6 +100,7 @@ public final class JTypeVar extends JClass implements JDeclaration {
     /**
      * Prints out the declaration of the variable.
      */
+    @Override
     public void declare(JFormatter f) {
         f.id(name);
         if(bound!=null)
@@ -93,6 +108,7 @@ public final class JTypeVar extends JClass implements JDeclaration {
     }
 
 
+    @Override
     protected JClass substituteParams(JTypeVar[] variables, List<JClass> bindings) {
         for(int i=0;i<variables.length;i++)
             if(variables[i]==this)
@@ -100,6 +116,7 @@ public final class JTypeVar extends JClass implements JDeclaration {
         return this;
     }
 
+    @Override
     public void generate(JFormatter f) {
         f.id(name);
     }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JTypeWildcard.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JTypeWildcard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -37,14 +37,17 @@ final class JTypeWildcard extends JClass {
         this.bound = bound;
     }
 
+    @Override
     public String name() {
         return "? extends "+bound.name();
     }
 
+    @Override
     public String fullName() {
         return "? extends "+bound.fullName();
     }
 
+    @Override
     public JPackage _package() {
         return null;
     }
@@ -55,6 +58,7 @@ final class JTypeWildcard extends JClass {
      * <p>
      * If no bound is given, this method returns {@link Object}.
      */
+    @Override
     public JClass _extends() {
         if(bound!=null)
             return bound;
@@ -65,18 +69,22 @@ final class JTypeWildcard extends JClass {
     /**
      * Returns the interface bounds of this variable.
      */
+    @Override
     public Iterator<JClass> _implements() {
         return bound._implements();
     }
 
+    @Override
     public boolean isInterface() {
         return false;
     }
 
+    @Override
     public boolean isAbstract() {
         return false;
     }
 
+    @Override
     protected JClass substituteParams(JTypeVar[] variables, List<JClass> bindings) {
         JClass nb = bound.substituteParams(variables,bindings);
         if(nb==bound)
@@ -85,6 +93,7 @@ final class JTypeWildcard extends JClass {
             return new JTypeWildcard(nb);
     }
 
+    @Override
     public void generate(JFormatter f) {
         if(bound._extends()==null)
             f.p("?");   // instead of "? extends Object"

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JVar.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JVar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -140,9 +140,10 @@ public class JVar extends JExpressionImpl implements JDeclaration, JAssignmentTa
      * @param clazz
      *          The annotation class to annotate the field with
      */
+    @Override
     public JAnnotationUse annotate(JClass clazz){
         if(annotations==null)
-           annotations = new ArrayList<JAnnotationUse>();
+           annotations = new ArrayList<>();
         JAnnotationUse a = new JAnnotationUse(clazz);
         annotations.add(a);
         return a;
@@ -154,21 +155,25 @@ public class JVar extends JExpressionImpl implements JDeclaration, JAssignmentTa
      * @param clazz
      *          The annotation class to annotate the field with
      */
+    @Override
     public JAnnotationUse annotate(Class <? extends Annotation> clazz){
         return annotate(type.owner().ref(clazz));
     }
 
+    @Override
     public <W extends JAnnotationWriter> W annotate2(Class<W> clazz) {
         return TypedAnnotationWriter.create(clazz,this);
     }
 
+    @Override
     public boolean removeAnnotation(JAnnotationUse annotation) {
         return this.annotations.remove(annotation);
     }
 
+    @Override
     public Collection<JAnnotationUse> annotations() {
         if (annotations == null)
-            annotations = new ArrayList<JAnnotationUse>();
+            annotations = new ArrayList<>();
         return Collections.unmodifiableList(annotations);
     }
 
@@ -186,18 +191,22 @@ public class JVar extends JExpressionImpl implements JDeclaration, JAssignmentTa
             f.p('=').g(init);
     }
 
+    @Override
     public void declare(JFormatter f) {
         f.b(this).p(';').nl();
     }
 
+    @Override
     public void generate(JFormatter f) {
         f.id(name);
     }
 
 	
+    @Override
     public JExpression assign(JExpression rhs) {
 		return JExpr.assign(this,rhs);
     }
+    @Override
     public JExpression assignPlus(JExpression rhs) {
 		return JExpr.assignPlus(this,rhs);
     }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JWhileLoop.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JWhileLoop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -43,6 +43,7 @@ public class JWhileLoop implements JStatement {
         return body;
     }
 
+    @Override
     public void state(JFormatter f) {
         if (JOp.hasTopOp(test)) {
             f.p("while ").g(test);

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/SecureLoader.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/SecureLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -24,6 +24,7 @@ class SecureLoader {
         } else {
             return (ClassLoader) java.security.AccessController.doPrivileged(
                     new java.security.PrivilegedAction() {
+                        @Override
                         public java.lang.Object run() {
                             return Thread.currentThread().getContextClassLoader();
                         }
@@ -37,6 +38,7 @@ class SecureLoader {
         } else {
             return (ClassLoader) java.security.AccessController.doPrivileged(
                     new java.security.PrivilegedAction() {
+                        @Override
                         public java.lang.Object run() {
                             return c.getClassLoader();
                         }
@@ -50,6 +52,7 @@ class SecureLoader {
         } else {
             return (ClassLoader) java.security.AccessController.doPrivileged(
                     new java.security.PrivilegedAction() {
+                        @Override
                         public java.lang.Object run() {
                             return ClassLoader.getSystemClassLoader();
                         }
@@ -63,6 +66,7 @@ class SecureLoader {
         } else {
             java.security.AccessController.doPrivileged(
                     new java.security.PrivilegedAction() {
+                        @Override
                         public java.lang.Object run() {
                             Thread.currentThread().setContextClassLoader(cl);
                             return null;

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/TypedAnnotationWriter.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/TypedAnnotationWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -54,15 +54,18 @@ class TypedAnnotationWriter<A extends Annotation,W extends JAnnotationWriter<A>>
         this.use = use;
     }
 
+    @Override
     public JAnnotationUse getAnnotationUse() {
         return use;
     }
 
+    @Override
     public Class<A> getAnnotationType() {
         return annotation;
     }
 
     @SuppressWarnings("unchecked")
+    @Override
 	public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
 
         if(method.getDeclaringClass()==JAnnotationWriter.class) {
@@ -141,7 +144,7 @@ class TypedAnnotationWriter<A extends Annotation,W extends JAnnotationWriter<A>>
     @SuppressWarnings("unchecked")
 	private Object addArrayValue(Object proxy,String name, Class itemType, Class expectedReturnType, Object arg) {
         if(arrays==null)
-            arrays = new HashMap<String,JAnnotationArrayMember>();
+            arrays = new HashMap<>();
         JAnnotationArrayMember m = arrays.get(name);
         if(m==null) {
             m = use.paramArray(name);

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/fmt/JBinaryFile.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/fmt/JBinaryFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -41,6 +41,7 @@ public final class JBinaryFile extends JResourceFile {
         return baos;
     }
     
+    @Override
     public void build(OutputStream os) throws IOException {
         os.write( baos.toByteArray() );
     }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/fmt/JPropertyFile.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/fmt/JPropertyFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -40,6 +40,7 @@ public class JPropertyFile extends JResourceFile
     // TODO: should we rather expose Properties object directly via
     // public Properties body() { return data; } ?
     
+    @Override
     public void build( OutputStream out ) throws IOException {
         data.store(out,null);
     }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/fmt/JSerializedObject.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/fmt/JSerializedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -37,6 +37,7 @@ public class JSerializedObject extends JResourceFile {
     /**
      * called by JPackage to serialize the object 
      */
+    @Override
     protected void build( OutputStream os ) throws IOException {
         // serialize the obj into a ByteArrayOutputStream
         ObjectOutputStream oos = new ObjectOutputStream(os);

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/fmt/JStaticFile.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/fmt/JStaticFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -47,10 +47,12 @@ public final class JStaticFile extends JResourceFile {
         this.isResource = isResource;
     }
 
+    @Override
     protected boolean isResource() {
         return isResource;
     }
 
+    @Override
     protected void build(OutputStream os) throws IOException {
         DataInputStream dis = new DataInputStream(classLoader.getResourceAsStream(resourceName));
         

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/fmt/JStaticJavaFile.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/fmt/JStaticJavaFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -74,10 +74,12 @@ public final class JStaticJavaFile extends JResourceFile {
         return clazz;
     }
 
+    @Override
     protected boolean isResource() {
         return false;
     }
 
+    @Override
     protected  void build(OutputStream os) throws IOException {
         int lineNumber=1;
         try (
@@ -107,6 +109,7 @@ public final class JStaticJavaFile extends JResourceFile {
     private LineFilter createLineFilter() {
         // this filter replaces the package declaration.
         LineFilter f = new LineFilter() {
+            @Override
             public String process(String line) {
                 if(!line.startsWith("package ")) return line;
 
@@ -154,6 +157,7 @@ public final class JStaticJavaFile extends JResourceFile {
             this.first=first;
             this.second=second;
         }
+        @Override
         public String process(String line) throws ParseException {
             line = first.process(line);
             if(line==null)  return null;
@@ -172,10 +176,12 @@ public final class JStaticJavaFile extends JResourceFile {
             typeParams = new JTypeVar[0];
         }
 
+        @Override
         public String name() {
             return className;
         }
 
+        @Override
         public String fullName() {
             if(pkg.isUnnamed())
                 return className;
@@ -183,30 +189,37 @@ public final class JStaticJavaFile extends JResourceFile {
                 return pkg.name()+'.'+className;
         }
 
+        @Override
         public JPackage _package() {
             return pkg;
         }
 
+        @Override
         public JClass _extends() {
             throw new UnsupportedOperationException();
         }
 
+        @Override
         public Iterator<JClass> _implements() {
             throw new UnsupportedOperationException();
         }
 
+        @Override
         public boolean isInterface() {
             throw new UnsupportedOperationException();
         }
 
+        @Override
         public boolean isAbstract() {
             throw new UnsupportedOperationException();
         }
 
+        @Override
         public JTypeVar[] typeParams() {
             return typeParams;
         }
 
+        @Override
         protected JClass substituteParams(JTypeVar[] variables, List<JClass> bindings) {
             return this;
         }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/fmt/JTextFile.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/fmt/JTextFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -36,6 +36,7 @@ public class JTextFile extends JResourceFile
         this.contents = _contents;
     }
     
+    @Override
     public void build( OutputStream out ) throws IOException {
         Writer w = new OutputStreamWriter(out);
         w.write(contents);

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/util/ClassNameComparator.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/util/ClassNameComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -23,6 +23,7 @@ import com.sun.codemodel.JClass;
 public class ClassNameComparator implements Comparator<JClass> {
     private ClassNameComparator() {}
     
+    @Override
     public int compare(JClass l, JClass r) {
         return l.fullName().compareTo(r.fullName());
     }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/util/JavadocEscapeWriter.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/util/JavadocEscapeWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -40,6 +40,7 @@ public class JavadocEscapeWriter extends FilterWriter {
         super(next);
     }
 
+    @Override
     public void write(int ch) throws IOException {
         if(ch=='<')
             out.write("&lt;");
@@ -53,19 +54,23 @@ public class JavadocEscapeWriter extends FilterWriter {
             out.write(ch);
     }
 
+    @Override
     public void write(char[] buf, int off, int len) throws IOException {
         for( int i=0; i<len; i++ )
             write(buf[off+i]);
     }
 
+    @Override
     public void write(char[] buf) throws IOException {
         write(buf,0,buf.length);
     }
 
+    @Override
     public void write(String buf, int off, int len) throws IOException {
         write( buf.toCharArray(), off, len );
     }
 
+    @Override
     public void write(String buf) throws IOException {
         write( buf.toCharArray(), 0, buf.length() );
     }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/util/UnicodeEscapeWriter.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/util/UnicodeEscapeWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -30,6 +30,7 @@ public class UnicodeEscapeWriter extends FilterWriter {
         super(next);
     }
 
+    @Override
     public final void write(int ch) throws IOException {
         if(!requireEscaping(ch))  out.write(ch);
         else {
@@ -55,19 +56,23 @@ public class UnicodeEscapeWriter extends FilterWriter {
         return false;
     }
     
+    @Override
     public final void write(char[] buf, int off, int len) throws IOException {
         for( int i=0; i<len; i++ )
             write(buf[off+i]);
     }
 
+    @Override
     public final void write(char[] buf) throws IOException {
         write(buf,0,buf.length);
     }
 
+    @Override
     public final void write(String buf, int off, int len) throws IOException {
         write( buf.toCharArray(), off, len );
     }
     
+    @Override
     public final void write(String buf) throws IOException {
         write( buf.toCharArray(), 0, buf.length() );
     }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/writer/OutputStreamCodeWriter.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/writer/OutputStreamCodeWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -43,15 +43,18 @@ public class OutputStreamCodeWriter extends CodeWriter {
 		this.encoding = encoding;
 	}
 
+        @Override
 	public OutputStream openBinary(JPackage pkg, String fileName)
 			throws IOException {
 		return new FilterOutputStream(out) {
+                @Override
 			public void close() {
 				// don't let this stream close
 			}
 		};
 	}
 
+        @Override
 	public void close() throws IOException {
 		out.close();
 	}

--- a/jaxb-ri/runtime/impl/src/main/java/module-info.java
+++ b/jaxb-ri/runtime/impl/src/main/java/module-info.java
@@ -35,6 +35,7 @@ module org.glassfish.jaxb.runtime {
     exports org.glassfish.jaxb.runtime.v2.model.impl;
     exports org.glassfish.jaxb.runtime.v2.model.runtime;
     exports org.glassfish.jaxb.runtime.v2.runtime;
+    exports org.glassfish.jaxb.runtime.v2.runtime.reflect;
     exports org.glassfish.jaxb.runtime.v2.runtime.unmarshaller;
     exports org.glassfish.jaxb.runtime.v2.schemagen;
     exports org.glassfish.jaxb.runtime.v2.schemagen.xmlschema;

--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/addon/sync/SynchronizedMethodAddOn.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/addon/sync/SynchronizedMethodAddOn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -54,7 +54,7 @@ public class SynchronizedMethodAddOn extends Plugin {
      */
     private void augument(ClassOutline co) {
         for (JMethod m : co.implClass.methods())
-            m.getMods().setSynchronized(true);
+            m.mods().setSynchronized(true);
     }
 
 }


### PR DESCRIPTION
make JAnnotationStringValue public (fixes #878),
minor improvements in CM for better usage on SE 11+,
add missing xjc export

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>