### PR TITLE
Backport: getCallerClassName returns default value if stack trace is empty or too small

### DIFF
--- a/jaxb-ri/runtime/impl/src/main/java/com/sun/xml/bind/StackHelper.java
+++ b/jaxb-ri/runtime/impl/src/main/java/com/sun/xml/bind/StackHelper.java
@@ -27,7 +27,10 @@ final class StackHelper {
      *                           prevents stack introspection
      */
     static String getCallerClassName() {
-       StackTraceElement[] trace = new Exception().getStackTrace();
-       return trace[2].getClassName();
+        StackTraceElement[] trace = new Exception().getStackTrace();
+        if (2 < trace.length) {
+            return trace[2].getClassName();
+        }
+        return "com.sun.xml.bind"; // Use the default
     }
 }


### PR DESCRIPTION
Signed-off-by: tvallin <thibault.vallin@oracle.com>