### PR TITLE
Fix equality on BISerializable

### DIFF
--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/bindinfo/BIGlobalBinding.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/bindinfo/BIGlobalBinding.java
@@ -534,7 +534,6 @@ public final class BIGlobalBinding extends AbstractDeclarationImpl {
             this.fixedAttributeAsConstantProperty == b.fixedAttributeAsConstantProperty &&
             this.generateEnumMemberName == b.generateEnumMemberName &&
             this.codeGenerationStrategy == b.codeGenerationStrategy &&
-            this.serializable == b.serializable &&
             this.superClass == b.superClass &&
             this.superInterface == b.superInterface &&
             this.generateElementClass == b.generateElementClass &&
@@ -552,6 +551,7 @@ public final class BIGlobalBinding extends AbstractDeclarationImpl {
                isEqual(this.noUnmarshaller, b.noUnmarshaller) &&
                isEqual(this.noValidator, b.noValidator) &&
                isEqual(this.noValidatingUnmarshaller, b.noValidatingUnmarshaller) &&
+               isEqual(this.serializable, b.serializable) &&
                isEqual(this.typeSubstitution, b.typeSubstitution) &&
                isEqual(this.simpleMode, b.simpleMode) &&
                isEqual(this.enumBaseTypes, b.enumBaseTypes) &&

--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/bindinfo/BISerializable.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/bindinfo/BISerializable.java
@@ -11,6 +11,7 @@
 package com.sun.tools.xjc.reader.xmlschema.bindinfo;
 
 import jakarta.xml.bind.annotation.XmlAttribute;
+import java.util.Objects;
 
 
 /**
@@ -26,4 +27,17 @@ public final class BISerializable {
     /** serial version UID, or null to avoid generating the serialVersionUID field. */
     @XmlAttribute
     public Long uid;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BISerializable that = (BISerializable) o;
+        return Objects.equals(uid, that.uid);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uid);
+    }
 }


### PR DESCRIPTION
If used in a GlobalBindings definition applied to multiple schema files, it might lead to an error `only one globalBindings customization is allowed in a whole compilation`. This is caused by XJC thinking there are multiple different GlobalBinding definitions, though there is just one being parsed multiple times.

Fixes an unresolved edge case as described in https://github.com/eclipse-ee4j/jaxb-ri/issues/687.

I need personally need this for the 2.3.x series. If it is still maintained, I can create a PR against the EE8 branch instead or in addition to this. (If not, I will just make a custom build of it.)