### PR TITLE
fix bug - Marshalling an object that overrides the parent's method, the XML that created contains both child's and parent's tag, the problem was in serializeBody method in the reflection section. the condition should check if the super class contains the declared field that the child overrides.

### DIFF
--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/ClassBeanInfoImpl.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/ClassBeanInfoImpl.java
@@ -334,7 +334,7 @@ public final class ClassBeanInfoImpl<BeanT> extends JaxBeanInfo<BeanT> implement
                 if (!isThereAnOverridingProperty || bean.getClass().equals(jaxbType)) {
                     p.serializeBody(bean, target, null);
                 } else if (isThereAnOverridingProperty) { 
-                    // need to double check the override - it should be safe to do after the model has been created because it's targeted to override properties only
+                    // need to double check the override - it should be safe to do after the model has been created because it's targeted to override properties only 
                     Class beanSuperClass = bean.getClass().getSuperclass();
                     if (Utils.REFLECTION_NAVIGATOR.getDeclaredField(beanSuperClass, p.getFieldName()) == null) {
                         p.serializeBody(bean, target, null);

--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/ClassBeanInfoImpl.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/ClassBeanInfoImpl.java
@@ -335,8 +335,8 @@ public final class ClassBeanInfoImpl<BeanT> extends JaxBeanInfo<BeanT> implement
                     p.serializeBody(bean, target, null);
                 } else if (isThereAnOverridingProperty) { 
                     // need to double check the override - it should be safe to do after the model has been created because it's targeted to override properties only
-                    Class beanClass = bean.getClass();
-                    if (Utils.REFLECTION_NAVIGATOR.getDeclaredField(beanClass, p.getFieldName()) == null) {
+                    Class beanSuperClass = bean.getClass().getSuperclass();
+                    if (Utils.REFLECTION_NAVIGATOR.getDeclaredField(beanSuperClass, p.getFieldName()) == null) {
                         p.serializeBody(bean, target, null);
                     }
                 }


### PR DESCRIPTION

**DTOs:**
```
@XmlRootElement(name = "parent")
public class ParentDTO {
	Protected String name;
	
    @XmlElement(name= “parentName”)
    public String getName() {
        return name;
    }

     public void setName(String name) {
        this.name = name;
    }
}



@XmlRootElement(name = "child")
public class ChildDTO extends ParentDTO {
	
   @Override
   @XmlElement(name="childName")
    public String getName() {
        return name;
    }
}

```

**Program:**
```
ChildDTO child = new ChildDTO();
child.setName("aaa");

final Marshaller marshaller = JAXBContext.newInstance(ChildDTO.class).createMarshaller();
marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
StringWriter stringWriter = new StringWriter();
marshaller.marshal(ChildDTO, stringWriter);
String xmlAsString = stringWriter.toString();

```

**XML after Marshall:** 
```
<child>
	<parentName>aa</parentName >
	<childName>aa</ childName >
</child>
```