### PR TITLE
Sonarqube Fixes #1603

### DIFF
--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JAnnotationArrayMember.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JAnnotationArrayMember.java
@@ -266,7 +266,7 @@ public final class JAnnotationArrayMember extends JAnnotationValue implements JA
      * @deprecated
      *      use {@link #annotate}
      */
-    @Deprecated
+    @Deprecated(since="4.0.0-SNAPSHOT", forRemoval=true)
     public JAnnotationArrayMember param (JAnnotationUse value ){
         values.add(value);
         return this;

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JAnnotationArrayMember.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JAnnotationArrayMember.java
@@ -266,7 +266,7 @@ public final class JAnnotationArrayMember extends JAnnotationValue implements JA
      * @deprecated
      *      use {@link #annotate}
      */
-    @Deprecated(since="4.0.0-SNAPSHOT", forRemoval=true)
+    @Deprecated(since="2.3", forRemoval=true)
     public JAnnotationArrayMember param (JAnnotationUse value ){
         values.add(value);
         return this;

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JAnnotationArrayMember.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JAnnotationArrayMember.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/jaxb-ri/core/src/main/java/org/glassfish/jaxb/core/marshaller/Messages.java
+++ b/jaxb-ri/core/src/main/java/org/glassfish/jaxb/core/marshaller/Messages.java
@@ -69,7 +69,7 @@ public class Messages {
     /**
      * @deprecated use ERR_MISSING_OBJECT2
      */
-    @Deprecated
+    @Deprecated(since="4.0.0-SNAPSHOT", forRemoval=true)
     public static final String ERR_MISSING_OBJECT = // 0 args
         "SAXMarshaller.MissingObject";
     
@@ -84,14 +84,14 @@ public class Messages {
     /**
      * @deprecated only used from 1.0
      */
-    @Deprecated
+    @Deprecated(since="4.0.0-SNAPSHOT", forRemoval=true)
     public static final String ERR_DANGLING_IDREF = // 1 arg
         "SAXMarshaller.DanglingIDREF";
 
     /**
      * @deprecated only used from 1.0
      */
-    @Deprecated
+    @Deprecated(since="4.0.0-SNAPSHOT", forRemoval=true)
     public static final String ERR_NOT_IDENTIFIABLE = // 0 args
         "SAXMarshaller.NotIdentifiable";
 

--- a/jaxb-ri/core/src/main/java/org/glassfish/jaxb/core/marshaller/Messages.java
+++ b/jaxb-ri/core/src/main/java/org/glassfish/jaxb/core/marshaller/Messages.java
@@ -69,7 +69,7 @@ public class Messages {
     /**
      * @deprecated use ERR_MISSING_OBJECT2
      */
-    @Deprecated(since="4.0.0-SNAPSHOT", forRemoval=true)
+    @Deprecated(since="2.0", forRemoval=true)
     public static final String ERR_MISSING_OBJECT = // 0 args
         "SAXMarshaller.MissingObject";
     
@@ -84,14 +84,14 @@ public class Messages {
     /**
      * @deprecated only used from 1.0
      */
-    @Deprecated(since="4.0.0-SNAPSHOT", forRemoval=true)
+    @Deprecated(since="2.0", forRemoval=true)
     public static final String ERR_DANGLING_IDREF = // 1 arg
         "SAXMarshaller.DanglingIDREF";
 
     /**
      * @deprecated only used from 1.0
      */
-    @Deprecated(since="4.0.0-SNAPSHOT", forRemoval=true)
+    @Deprecated(since="2.0", forRemoval=true)
     public static final String ERR_NOT_IDENTIFIABLE = // 0 args
         "SAXMarshaller.NotIdentifiable";
 

--- a/jaxb-ri/core/src/main/java/org/glassfish/jaxb/core/marshaller/Messages.java
+++ b/jaxb-ri/core/src/main/java/org/glassfish/jaxb/core/marshaller/Messages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/jaxb-ri/core/src/main/java/org/glassfish/jaxb/core/unmarshaller/DOMScanner.java
+++ b/jaxb-ri/core/src/main/java/org/glassfish/jaxb/core/unmarshaller/DOMScanner.java
@@ -121,7 +121,7 @@ public class DOMScanner implements LocatorEx,InfosetScanner<Node> {
      * @deprecated in JAXB 2.0
      *      Use {@link #scan(Element)}
      */
-    @Deprecated
+    @Deprecated(since="4.0.0-SNAPSHOT", forRemoval=true)
     public void parse( Element e, ContentHandler handler ) throws SAXException {
         // it might be better to set receiver at the constructor.
         receiver = handler;
@@ -143,7 +143,7 @@ public class DOMScanner implements LocatorEx,InfosetScanner<Node> {
      * @deprecated in JAXB 2.0
      *      Use {@link #scan(Element)}
      */
-    @Deprecated
+    @Deprecated(since="4.0.0-SNAPSHOT", forRemoval=true)
     public void parseWithContext( Element e, ContentHandler handler ) throws SAXException {
         setContentHandler(handler);
         scan(e);

--- a/jaxb-ri/core/src/main/java/org/glassfish/jaxb/core/unmarshaller/DOMScanner.java
+++ b/jaxb-ri/core/src/main/java/org/glassfish/jaxb/core/unmarshaller/DOMScanner.java
@@ -121,7 +121,7 @@ public class DOMScanner implements LocatorEx,InfosetScanner<Node> {
      * @deprecated in JAXB 2.0
      *      Use {@link #scan(Element)}
      */
-    @Deprecated(since="4.0.0-SNAPSHOT", forRemoval=true)
+    @Deprecated(since="2.0", forRemoval=true)
     public void parse( Element e, ContentHandler handler ) throws SAXException {
         // it might be better to set receiver at the constructor.
         receiver = handler;
@@ -143,7 +143,7 @@ public class DOMScanner implements LocatorEx,InfosetScanner<Node> {
      * @deprecated in JAXB 2.0
      *      Use {@link #scan(Element)}
      */
-    @Deprecated(since="4.0.0-SNAPSHOT", forRemoval=true)
+    @Deprecated(since="2.0", forRemoval=true)
     public void parseWithContext( Element e, ContentHandler handler ) throws SAXException {
         setContentHandler(handler);
         scan(e);

--- a/jaxb-ri/core/src/main/java/org/glassfish/jaxb/core/unmarshaller/DOMScanner.java
+++ b/jaxb-ri/core/src/main/java/org/glassfish/jaxb/core/unmarshaller/DOMScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/jaxb-ri/jxc/src/main/java/com/sun/tools/jxc/ConfigReader.java
+++ b/jaxb-ri/jxc/src/main/java/com/sun/tools/jxc/ConfigReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/jaxb-ri/jxc/src/main/java/com/sun/tools/jxc/ConfigReader.java
+++ b/jaxb-ri/jxc/src/main/java/com/sun/tools/jxc/ConfigReader.java
@@ -58,7 +58,7 @@ public final class ConfigReader  {
      * The set of classes to be passed to XJC
      *
      */
-    private final Set<Reference> classesToBeIncluded = new HashSet<Reference>();
+    private final Set<Reference> classesToBeIncluded = new HashSet<>();
 
 
     /**
@@ -229,7 +229,7 @@ public final class ConfigReader  {
          * Namespace URI to the location of the schema.
          * This captures what the user specifies.
          */
-        private final Map<String,File> schemas = new HashMap<String,File>();
+        private final Map<String,File> schemas = new HashMap<>();
 
 
         /**

--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/Coordinator.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/Coordinator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/Coordinator.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/Coordinator.java
@@ -78,7 +78,7 @@ public abstract class Coordinator implements ErrorHandler, ValidationEventHandle
     }
 
     // this much is necessary to avoid calling get and set twice when we push.
-    private static final ThreadLocal<Coordinator> activeTable = new ThreadLocal<Coordinator>();
+    private static final ThreadLocal<Coordinator> activeTable = new ThreadLocal<>();
 
     /**
      * The {@link Coordinator} in charge before this {@link Coordinator}.

--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/reflect/Lister.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/reflect/Lister.java
@@ -212,7 +212,7 @@ public abstract class Lister<BeanT,PropT,ItemT,PackT> {
     /**
      * Listers for the primitive type arrays, keyed by their primitive Class object.
      */
-    /*package*/ static final Map<Class,Lister> primitiveArrayListers = new HashMap<Class,Lister>();
+    /*package*/ static final Map<Class,Lister> primitiveArrayListers = new HashMap<>();
 
     static {
         // register primitive array listers

--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/reflect/Lister.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/reflect/Lister.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/XSSchema.java
+++ b/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/XSSchema.java
@@ -113,7 +113,7 @@ public interface XSSchema extends XSComponent
      *      this method from {@link XSSchema} and not from {@link XSComponent},
      *      there's something wrong with your code.
      */
-    @Deprecated(since="4.0.0-SNAPSHOT", forRemoval=true)
+    @Deprecated(since="2.3", forRemoval=true)
     SchemaDocument getSourceDocument();
 
     /**

--- a/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/XSSchema.java
+++ b/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/XSSchema.java
@@ -113,7 +113,7 @@ public interface XSSchema extends XSComponent
      *      this method from {@link XSSchema} and not from {@link XSComponent},
      *      there's something wrong with your code.
      */
-    @Deprecated
+    @Deprecated(since="4.0.0-SNAPSHOT", forRemoval=true)
     SchemaDocument getSourceDocument();
 
     /**

--- a/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/XSSchema.java
+++ b/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/XSSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/impl/parser/SAXParserFactoryAdaptor.java
+++ b/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/impl/parser/SAXParserFactoryAdaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/impl/scd/SimpleCharStream.java
+++ b/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/impl/scd/SimpleCharStream.java
@@ -212,7 +212,7 @@ public class SimpleCharStream
    * @deprecated 
    * @see #getEndColumn
    */
-  @Deprecated(since="4.0.0-SNAPSHOT", forRemoval=true)
+  @Deprecated(since="2.3", forRemoval=true)
   public int getColumn() {
      return bufcolumn[bufpos];
   }
@@ -221,7 +221,7 @@ public class SimpleCharStream
    * @deprecated 
    * @see #getEndLine
    */
-  @Deprecated(since="4.0.0-SNAPSHOT", forRemoval=true)
+  @Deprecated(since="2.3", forRemoval=true)
   public int getLine() {
      return bufline[bufpos];
   }

--- a/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/impl/scd/SimpleCharStream.java
+++ b/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/impl/scd/SimpleCharStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at

--- a/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/impl/scd/SimpleCharStream.java
+++ b/jaxb-ri/xsom/src/main/java/com/sun/xml/xsom/impl/scd/SimpleCharStream.java
@@ -212,7 +212,7 @@ public class SimpleCharStream
    * @deprecated 
    * @see #getEndColumn
    */
-  @Deprecated
+  @Deprecated(since="4.0.0-SNAPSHOT", forRemoval=true)
   public int getColumn() {
      return bufcolumn[bufpos];
   }
@@ -221,7 +221,7 @@ public class SimpleCharStream
    * @deprecated 
    * @see #getEndLine
    */
-  @Deprecated
+  @Deprecated(since="4.0.0-SNAPSHOT", forRemoval=true)
   public int getLine() {
      return bufline[bufpos];
   }


### PR DESCRIPTION
https://github.com/eclipse-ee4j/jaxb-ri/issues/1603

xsom/src/main/java/com/sun/xml/xsom/XSSchema.java
    Add 'since' and/or 'forRemoval' arguments to the @deprecated annotation. [squid:MissingDeprecatedCheck]
jxc/src/main/java/com/sun/tools/jxc/ConfigReader.java
    Replace the type specification in this constructor call with the diamond operator ("<>"). [squid:S2293]
runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/reflect/Lister.java
    Replace the type specification in this constructor call with the diamond operator ("<>"). [squid:S2293]
xsom/src/main/java/com/sun/xml/xsom/impl/scd/SimpleCharStream.java
    Add 'since' and/or 'forRemoval' arguments to the @deprecated annotation. [squid:MissingDeprecatedCheck]
core/src/main/java/org/glassfish/jaxb/core/marshaller/Messages.java
    Add 'since' and/or 'forRemoval' arguments to the @deprecated annotation. [squid:MissingDeprecatedCheck]
xsom/src/main/java/com/sun/xml/xsom/impl/parser/SAXParserFactoryAdaptor.java
    Add 'since' and/or 'forRemoval' arguments to the @deprecated annotation. [squid:MissingDeprecatedCheck]
core/src/main/java/org/glassfish/jaxb/core/unmarshaller/DOMScanner.java
    Add 'since' and/or 'forRemoval' arguments to the @deprecated annotation. [squid:MissingDeprecatedCheck]
codemodel/codemodel/src/main/java/com/sun/codemodel/JAnnotationArrayMember.java
    Add 'since' and/or 'forRemoval' arguments to the @deprecated annotation. [squid:MissingDeprecatedCheck]
runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/Coordinator.java
    Replace the type specification in this constructor call with the diamond operator ("<>"). [squid:S2293]