### PR TITLE
#936: Fix lost whitespaces (including linebreaks) on unmarshalling

### DIFF
--- a/jaxb-ri/docs/release-documentation/src/docbook/jaxb-changelog.xml
+++ b/jaxb-ri/docs/release-documentation/src/docbook/jaxb-changelog.xml
@@ -33,6 +33,9 @@
                 <itemizedlist>
                     <listitem><para>Fix equality on BISerializable</para></listitem>
                     <listitem><para>
+                        <link xlink:href="https://github.com/eclipse-ee4j/jaxb-ri/issues/936">#936</link>: problem with XMLMixed in a tag annotated XmlAnyElement
+                    </para></listitem>
+                    <listitem><para>
                         <link xlink:href="https://github.com/eclipse-ee4j/jaxb-ri/issues/1489">#1489</link>: DOMScanner ignores default namespace at scan method
                     </para></listitem>
                     <listitem><para>

--- a/jaxb-ri/runtime/impl/pom.xml
+++ b/jaxb-ri/runtime/impl/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -33,6 +33,7 @@
     <properties>
         <spotbugs.exclude>${project.basedir}/exclude-runtime.xml</spotbugs.exclude>
         <argLine>
+            --add-opens org.glassfish.jaxb.runtime/org.glassfish.jaxb.runtime.unmarshaller=jakarta.xml.bind
             --add-opens org.glassfish.jaxb.runtime/org.glassfish.jaxb.runtime.v2=jakarta.xml.bind
             --add-opens org.glassfish.jaxb.runtime/org.glassfish.jaxb.runtime.v2.runtime=jakarta.xml.bind
             --add-opens org.glassfish.jaxb.runtime/org.glassfish.jaxb.runtime.v2=org.glassfish.jaxb.core

--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/unmarshaller/UnmarshallingContext.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/unmarshaller/UnmarshallingContext.java
@@ -280,7 +280,7 @@ public final class UnmarshallingContext extends Coordinator
             assert prev!=null;
             loader = null;
             nil = false;
-            mixed = false;
+            mixed = prev.mixed;
             receiver = null;
             intercepter = null;
             elementDefaultValue = null;

--- a/jaxb-ri/runtime/impl/src/test/java/org/glassfish/jaxb/runtime/unmarshaller/CrLfMarshalUnmarshalTest.java
+++ b/jaxb-ri/runtime/impl/src/test/java/org/glassfish/jaxb/runtime/unmarshaller/CrLfMarshalUnmarshalTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package org.glassfish.jaxb.runtime.unmarshaller;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMResult;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.StringReader;
+import java.io.StringWriter;
+
+public class CrLfMarshalUnmarshalTest {
+
+    private static final String VALUE = "abc\r\nd\re\nf";
+    private Bean fElem;
+    private Marshaller fMarshaller;
+    private Unmarshaller fUnmarshaller;
+
+    @Before
+    public void setUp() throws Exception {
+        JAXBContext ctx = JAXBContext.newInstance(Bean.class);
+        fMarshaller = ctx.createMarshaller();
+        fUnmarshaller = ctx.createUnmarshaller();
+
+        fElem = new Bean();
+        fElem.setAttributeString(VALUE);
+        fElem.setElementString(VALUE);
+    }
+
+    @Test
+    public void testWriter() throws Exception {
+        StringWriter sw = new StringWriter();
+        fMarshaller.marshal(fElem, sw);
+        String resultXml = sw.toString();
+        System.out.println(resultXml);
+        Bean resultElem = (Bean) fUnmarshaller.unmarshal(new StringReader(resultXml));
+        Assert.assertEquals(VALUE, resultElem.getAttributeString());
+        Assert.assertEquals(VALUE, resultElem.getElementString());
+    }
+
+    @Test
+    public void testDomAndTransform() throws Exception {
+        StringWriter sw = new StringWriter();
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        DocumentBuilder db = dbf.newDocumentBuilder();
+        Document d = db.newDocument();
+        DOMResult result = new DOMResult(d);
+        fMarshaller.marshal(fElem, result);
+        Transformer tf = TransformerFactory.newInstance().newTransformer();
+        tf.transform(new DOMSource(d), new StreamResult(sw));
+        String resultXml = sw.toString();
+        System.out.println(resultXml);
+        Bean resultElem = (Bean) fUnmarshaller.unmarshal(new StringReader(resultXml));
+        Assert.assertEquals(VALUE, resultElem.getAttributeString());
+        Assert.assertEquals(VALUE, resultElem.getElementString());
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {"fElementString", "fAttributeString"})
+    @XmlRootElement(name = "Bean")
+    public static class Bean {
+
+        @XmlElement(name = "ElementString")
+        protected String fElementString;
+
+        @XmlAttribute(name = "AttributeString")
+        protected String fAttributeString;
+
+        public String getElementString() {
+            return fElementString;
+        }
+
+        public void setElementString(String elementString) {
+            fElementString = elementString;
+        }
+
+        public String getAttributeString() {
+            return fAttributeString;
+        }
+
+        public void setAttributeString(String attributeString) {
+            fAttributeString = attributeString;
+        }
+    }
+}

--- a/jaxb-ri/runtime/impl/src/test/java/org/glassfish/jaxb/runtime/unmarshaller/UnmarshallingXmlAnyElementMixedWithWhitespacesTest.java
+++ b/jaxb-ri/runtime/impl/src/test/java/org/glassfish/jaxb/runtime/unmarshaller/UnmarshallingXmlAnyElementMixedWithWhitespacesTest.java
@@ -1,4 +1,14 @@
-package com.sun.xml.bind.v2;
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package org.glassfish.jaxb.runtime.unmarshaller;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;

--- a/jaxb-ri/runtime/impl/src/test/java/org/glassfish/jaxb/runtime/v2/UnmarshallingXmlAnyElementMixedWithWhitespacesTest.java
+++ b/jaxb-ri/runtime/impl/src/test/java/org/glassfish/jaxb/runtime/v2/UnmarshallingXmlAnyElementMixedWithWhitespacesTest.java
@@ -1,0 +1,186 @@
+package com.sun.xml.bind.v2;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAnyElement;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementRef;
+import jakarta.xml.bind.annotation.XmlElementRefs;
+import jakarta.xml.bind.annotation.XmlMixed;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlValue;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.w3c.dom.Element;
+
+import javax.xml.transform.stream.StreamSource;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class UnmarshallingXmlAnyElementMixedWithWhitespacesTest {
+
+    private static final String BASIC_BODY_SAMPLE =
+            "<body><ul><li> <span>l</span></li> <li> <span> l</span></li><li> <span> </span> </li></ul></body>";
+
+    private static final String BODY_WITH_NEWLINE_SAMPLE =
+            "<body><ul><li>\n<span>l</span></li>\n<li>\n<span>\nl</span></li><li>\n<span>\n</span>\n</li></ul></body>";
+
+    private static final String DOCUMENT_SAMPLE = "<document> "
+            + "<metadata key=\"name\"> testing document</metadata>"
+            + " <metadata key=\"timestamp\">123456789</metadata>"
+            + " <content>"
+            + " <header>header</header> "
+            + "<body><ul><li> <span>l</span></li> <li> <span> l</span></li><li> <span> </span> </li></ul></body>"
+            + " <footer>footer</footer>"
+            + " </content> "
+            + "</document>";
+
+    private static final String DOCUMENT_EXPECTED = "<document>"
+            + "<metadata key=\"name\"> testing document</metadata>"
+            + "<metadata key=\"timestamp\">123456789</metadata>"
+            + "<content>"
+            + "<header>header</header>"
+            + "<body><ul><li> <span>l</span></li> <li> <span> l</span></li><li> <span> </span> </li></ul></body>"
+            + "<footer>footer</footer>"
+            + "</content>"
+            + "</document>";
+
+    private static final String MIXED_CONTENT_SAMPLE = "<composition>Some text before, " + DOCUMENT_SAMPLE + "\n"
+            + " between " + DOCUMENT_SAMPLE + " and after</composition>";
+
+    private static final String MIXED_CONTENT_EXPECTED = "<composition>Some text before, " + DOCUMENT_EXPECTED + "\n"
+            + " between " + DOCUMENT_EXPECTED + " and after</composition>";
+
+    private static JAXBContext context;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        context = JAXBContext.newInstance(MixedContent.class);
+    }
+
+    @Test
+    public void shouldParseAndSerializeKeepingWhitespacesWithSingleMixed() throws JAXBException {
+        // given
+        Unmarshaller unmarshaller = context.createUnmarshaller();
+        InputStream inputStream = new ByteArrayInputStream(BASIC_BODY_SAMPLE.getBytes(StandardCharsets.UTF_8));
+        // when
+        JAXBElement<Body> element = unmarshaller.unmarshal(new StreamSource(inputStream), Body.class);
+        String actual = serializeObject(element);
+        // then
+        assertEquals(BASIC_BODY_SAMPLE, actual);
+    }
+
+    @Test
+    public void shouldParseAndSerializeKeepingLineBreaksWithSingleMixed() throws JAXBException {
+        // given
+        Unmarshaller unmarshaller = context.createUnmarshaller();
+        InputStream inputStream = new ByteArrayInputStream(BODY_WITH_NEWLINE_SAMPLE.getBytes(StandardCharsets.UTF_8));
+        // when
+        JAXBElement<Body> element = unmarshaller.unmarshal(new StreamSource(inputStream), Body.class);
+        String actual = serializeObject(element);
+        // then
+        assertEquals(BODY_WITH_NEWLINE_SAMPLE, actual);
+    }
+
+    @Test
+    public void shouldParseAndSerializeKeepingWhitespacesOnMixedWithSiblings() throws JAXBException {
+        // given
+        Unmarshaller unmarshaller = context.createUnmarshaller();
+        InputStream inputStream = new ByteArrayInputStream(DOCUMENT_SAMPLE.getBytes(StandardCharsets.UTF_8));
+        // when
+        JAXBElement<Document> element = unmarshaller.unmarshal(new StreamSource(inputStream), Document.class);
+        String actual = serializeObject(element);
+        // then
+        assertEquals(DOCUMENT_EXPECTED, actual);
+    }
+
+    @Test
+    public void shouldParseAndSerializeKeepingWhitespacesOnMixedWithElementRefs() throws JAXBException {
+        // given
+        Unmarshaller unmarshaller = context.createUnmarshaller();
+        InputStream inputStream = new ByteArrayInputStream(MIXED_CONTENT_SAMPLE.getBytes(StandardCharsets.UTF_8));
+        // when
+        JAXBElement<MixedContent> element = unmarshaller.unmarshal(new StreamSource(inputStream), MixedContent.class);
+        String actual = serializeObject(element);
+        // then
+        assertEquals(MIXED_CONTENT_EXPECTED, actual);
+        assertTrue(element.getValue().elements.get(0) instanceof String);
+        assertTrue(element.getValue().elements.get(1) instanceof Document);
+    }
+
+    private String serializeObject(JAXBElement<?> element) throws JAXBException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        Marshaller marshaller = context.createMarshaller();
+        marshaller.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
+        marshaller.marshal(element.getValue(), outputStream);
+        return new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlRootElement(name = "document")
+    private static class Document {
+
+        @XmlElement
+        private List<Metadata> metadata;
+
+        @XmlElement
+        private Content content;
+
+        @XmlAccessorType(XmlAccessType.FIELD)
+        @XmlRootElement(name = "metadata")
+        private static class Metadata {
+
+            @XmlAttribute
+            private String key;
+
+            @XmlValue
+            private String value;
+        }
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlRootElement(name = "content")
+    private static class Content {
+
+        @XmlElement
+        private String header;
+
+        @XmlElement
+        private Body body;
+
+        @XmlElement
+        private String footer;
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlRootElement(name = "body")
+    private static class Body {
+
+        @XmlAnyElement
+        @XmlMixed
+        private List<Element> nodes;
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlRootElement(name = "composition")
+    private static class MixedContent {
+
+        @XmlAnyElement
+        @XmlElementRefs({@XmlElementRef(name = "document", type = Document.class)})
+        @XmlMixed
+        private List<Object> elements;
+    }
+
+}

--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/internalizer/DOMForest.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/internalizer/DOMForest.java
@@ -304,7 +304,7 @@ public final class DOMForest {
     private ContentHandler getParserHandler( Document dom ) {
         ContentHandler handler = new DOMBuilder(dom,locatorTable,outerMostBindings);
         handler = new WhitespaceStripper(handler,errorReceiver,entityResolver);
-        handler = new CustomHandler(handler, errorReceiver, entityResolver);
+        handler = new JAXBv2NSHandler(handler, errorReceiver, entityResolver);
         handler = new VersionChecker(handler,errorReceiver,entityResolver);
 
         // insert the reference finder so that

--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/internalizer/JAXBv2NSHandler.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/internalizer/JAXBv2NSHandler.java
@@ -27,7 +27,7 @@ import org.xml.sax.helpers.XMLFilterImpl;
  * to version 3.0 and prints warnings.
  *
  */
-final class CustomHandler extends XMLFilterImpl {
+final class JAXBv2NSHandler extends XMLFilterImpl {
 
     private Locator locator;
 
@@ -45,7 +45,7 @@ final class CustomHandler extends XMLFilterImpl {
     /** Will be set to true once we hit a JAXB 2.x binding version attribute declaration. */
     private boolean seenOldBindingsVersion = false;
 
-    public CustomHandler(ContentHandler handler, ErrorHandler eh, EntityResolver er) {
+    public JAXBv2NSHandler(ContentHandler handler, ErrorHandler eh, EntityResolver er) {
         setContentHandler(handler);
         if(eh!=null)    setErrorHandler(eh);
         if(er!=null)    setEntityResolver(er);


### PR DESCRIPTION
replaces #1336 and fixes #936
Also adds additional test for handling CR