### PR TITLE
jaxb-tck/issues/78 switch to https://www.w3.org/2005/05/xmlmime

### DIFF
--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/schemagen/XmlSchemaGenerator.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/schemagen/XmlSchemaGenerator.java
@@ -622,7 +622,7 @@ public final class XmlSchemaGenerator<T,C,F,M> {
                     schema._import().namespace(WellKnownNamespace.SWA_URI).schemaLocation("http://ws-i.org/profiles/basic/1.1/swaref.xsd");
                 }
                 if(useMimeNs) {
-                    schema._import().namespace(WellKnownNamespace.XML_MIME_URI).schemaLocation("http://www.w3.org/2005/05/xmlmime");
+                    schema._import().namespace(WellKnownNamespace.XML_MIME_URI).schemaLocation("https://www.w3.org/2005/05/xmlmime");
                 }
 
                 // then write each component


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

This change doesn't seem to help directly with https://github.com/eclipse-ee4j/jaxb-tck/issues/78 but will create a draft pr in case we want to merge it anyway (we can switch to ready for review).  I immediately saw the following failures with this change, so it didn't seem to help:
```
Sep 13, 2022, 3:09:54 PM Finished api/jakarta_xml/bind/JAXBContext/java2schema/CustomizedMapping/packages/XmlAccessorType/srcInherit5.html#testCase0001 Failed. test cases: 1; all failed; first test case failure: compileSchema
Pass: 181  Fail: 1  Error: 0  Not-Run: 24,444    
Sep 13, 2022, 3:09:54 PM Finished api/jakarta_xml/bind/JAXBContext/java2schema/CustomizedMapping/packages/XmlAccessorType/srcInherit5.html#testCase0002 Failed. test cases: 1; all failed; first test case failure: compileSchema
Pass: 181  Fail: 2  Error: 0  Not-Run: 24,443    
Sep 13, 2022, 3:09:54 PM Finished api/jakarta_xml/bind/JAXBContext/java2schema/CustomizedMapping/packages/XmlAccessorType/srcInherit5.html#testCase0003 Failed. test cases: 1; all failed; first test case failure: compileSchema
Pass: 181  Fail: 3  Error: 0  Not-Run: 24,442    
Sep 13, 2022, 3:09:54 PM Finished api/jakarta_xml/bind/JAXBContext/java2schema/CustomizedMapping/packages/XmlAccessorType/srcNone.html#testCase0001 Failed. test cases: 1; all failed; first test case failure: compileSchema
Pass: 181  Fail: 4  Error: 0  Not-Run: 24,441    
Sep 13, 2022, 3:09:54 PM Finished api/jakarta_xml/bind/JAXBContext/java2schema/CustomizedMapping/packages/XmlAccessorType/srcNone.html#testCase0002 Failed. test cases: 1; all failed; first test case failure: compileSchema
Pass: 181  Fail: 5  Error: 0  Not-Run: 24,440    
Sep 13, 2022, 3:09:54 PM Finished api/jakarta_xml/bind/JAXBContext/java2schema/CustomizedMapping/packages/XmlAccessorType/srcNone.html#testCase0003 Failed. test cases: 1; all failed; first test case failure: compileSchema
```

