### PR TITLE
[codemodel] Support `Object` and overridden `JAnnotationWriter` methods

### DIFF
--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/TypedAnnotationWriter.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/TypedAnnotationWriter.java
@@ -64,13 +64,35 @@ class TypedAnnotationWriter<A extends Annotation,W extends JAnnotationWriter<A>>
         return annotation;
     }
 
+    private static Method getOverriddenJAnnotationWriterMethod(Method method) {
+        if(method.getDeclaringClass()==JAnnotationWriter.class) {
+            return method;
+        }
+        try {
+            return JAnnotationWriter.class.getMethod(method.getName(), method.getParameterTypes());
+        } catch (NoSuchMethodException __) {
+        }
+        return null;
+    }
+
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        if (method.getDeclaringClass() == Object.class) {
+            switch (method.getName()) {
+                case "equals":
+                    return proxy == args[0];
+                case "hashCode":
+                    return System.identityHashCode(proxy);
+                case "toString":
+                    return proxy.getClass().getName() + '@' + Integer.toHexString(proxy.hashCode());
+            }
+        }
 
-        if(method.getDeclaringClass()==JAnnotationWriter.class) {
+        Method overridenMethod = getOverriddenJAnnotationWriterMethod(method);
+        if(overridenMethod != null) {
             try {
-                return method.invoke(this,args);
+                return overridenMethod.invoke(this,args);
             } catch (InvocationTargetException e) {
                 throw e.getTargetException();
             }

--- a/jaxb-ri/codemodel/codemodel/src/test/java/com/sun/codemodel/tests/AnnotationUseTest.java
+++ b/jaxb-ri/codemodel/codemodel/src/test/java/com/sun/codemodel/tests/AnnotationUseTest.java
@@ -90,6 +90,10 @@ public class AnnotationUseTest {
 
 		// test typed annotation writer
 		XmlElementW w = cls.annotate2(XmlElementW.class);
+		Assert.assertEquals(w, w);
+		Assert.assertEquals(System.identityHashCode(w), w.hashCode());
+		w.toString();
+		Assert.assertEquals(XmlElement.class, w.getAnnotationType());
 		w.ns("##default").value("foobar");
 
 		// adding an annotation as a member value pair
@@ -117,9 +121,13 @@ public class AnnotationUseTest {
 	}
 
 	interface XmlElementW extends JAnnotationWriter<XmlElement> {
+		@Override default Class<XmlElement> getAnnotationType() { return XmlElement.class; }
+
 		XmlElementW value(String s);
 
 		XmlElementW ns(String s);
+
+		@Override boolean equals(Object obj);
 	}
 }
 
@@ -130,6 +138,7 @@ public class AnnotationUseTest {
  * 
  * @java.lang.annotation.Retention(value1 =
  * java.lang.annotation.RetentionPolicy.RUNTIME, value = Test.Iamenum.GOOD)
+ * @XmlElement(ns = "##default", value = "foobar")
  * public class Test {
  * 
  * @java.lang.annotation.Retention(foo = @java.lang.annotation.Target(junk = 7)


### PR DESCRIPTION
Previously, if an overridable `Object` method was called on a `TypedAnnotationWriter` proxy, then an `IllegalArgumentException` would’ve been thrown.

Similarly, if the interface extending `JAnnotationWriter` had overridden a `JAnnotationWriter` method, such as `JAnnotationWriter::getAnnotationType`, then `TypedAnnotationWriter` would also throw `IllegalArgumentException`.

This fixes both cases.