### PR TITLE
[codemodel] Use canonical modifier order

### DIFF
--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JClass.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JClass.java
@@ -39,13 +39,13 @@ public abstract class JClass extends JType {
      *  {@code java.lang.String}.
      */
     @Override
-    abstract public String name();
+    public abstract String name();
 	
 	/**
      * Gets the package to which this class belongs.
      * TODO: shall we move move this down?
      */
-    abstract public JPackage _package();
+    public abstract JPackage _package();
 
     /**
      * Returns the class in which this class is nested, or {@code null} if
@@ -71,7 +71,7 @@ public abstract class JClass extends JType {
      *       for {@link Object}.
      *      If this JClass represents {@link Object}, return null.
      */
-    abstract public JClass _extends();
+    public abstract JClass _extends();
     
     /**
      * Iterates all super interfaces directly implemented by
@@ -82,7 +82,7 @@ public abstract class JClass extends JType {
      *         objects that represents those interfaces
      *		implemented by this object.
      */
-    abstract public Iterator<JClass> _implements();
+    public abstract Iterator<JClass> _implements();
     
     /**
      * Iterates all the type parameters of this class/interface.
@@ -104,12 +104,12 @@ public abstract class JClass extends JType {
     /**
      * Checks if this object represents an interface.
      */
-    abstract public boolean isInterface();
+    public abstract boolean isInterface();
 
     /**
      * Checks if this class is an abstract class.
      */
-    abstract public boolean isAbstract();
+    public abstract boolean isAbstract();
 
     /**
      * If this class represents one of the wrapper classes

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JMod.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JMod.java
@@ -19,15 +19,15 @@ public final class JMod {
     private JMod() {
     }
 
-    public final static int NONE         = 0x000;
-    public final static int PUBLIC       = 0x001;
-    public final static int PROTECTED    = 0x002;
-    public final static int PRIVATE      = 0x004;
-    public final static int FINAL        = 0x008;
-    public final static int STATIC       = 0x010;
-    public final static int ABSTRACT     = 0x020;
-    public final static int NATIVE       = 0x040;
-    public final static int SYNCHRONIZED = 0x080;
-    public final static int TRANSIENT    = 0x100;
-    public final static int VOLATILE     = 0x200;
+    public static final int NONE         = 0x000;
+    public static final int PUBLIC       = 0x001;
+    public static final int PROTECTED    = 0x002;
+    public static final int PRIVATE      = 0x004;
+    public static final int FINAL        = 0x008;
+    public static final int STATIC       = 0x010;
+    public static final int ABSTRACT     = 0x020;
+    public static final int NATIVE       = 0x040;
+    public static final int SYNCHRONIZED = 0x080;
+    public static final int TRANSIENT    = 0x100;
+    public static final int VOLATILE     = 0x200;
 }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JMods.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JMods.java
@@ -33,7 +33,7 @@ public class JMods implements JGenerable {
     /** bit-packed representation of modifiers. */
     private int mods;
 
-    private JMods(int mods) {
+    JMods(int mods) {
         this.mods = mods;
     }
 
@@ -125,14 +125,16 @@ public class JMods implements JGenerable {
         if ((mods & JMod.PUBLIC) != 0)        f.p("public");
         if ((mods & JMod.PROTECTED) != 0)     f.p("protected");
         if ((mods & JMod.PRIVATE) != 0)       f.p("private");
-        if ((mods & JMod.FINAL) != 0)         f.p("final");
-        if ((mods & JMod.STATIC) != 0)        f.p("static");
+
+        // Match canonical order in java.lang.reflect.Modifier::toString
         if ((mods & JMod.ABSTRACT) != 0)      f.p("abstract");
-        if ((mods & JMod.NATIVE) != 0)        f.p("native");
-        if ((mods & JMod.SYNCHRONIZED) != 0)  f.p("synchronized");
+        if ((mods & JMod.STATIC) != 0)        f.p("static");
+        if ((mods & JMod.FINAL) != 0)         f.p("final");
         if ((mods & JMod.TRANSIENT) != 0)     f.p("transient");
         if ((mods & JMod.VOLATILE) != 0)      f.p("volatile");
-        }
+        if ((mods & JMod.SYNCHRONIZED) != 0)  f.p("synchronized");
+        if ((mods & JMod.NATIVE) != 0)        f.p("native");
+    }
 
     @Override
     public String toString() {

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JOp.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JOp.java
@@ -15,7 +15,7 @@ package com.sun.codemodel;
  * JClass for generating expressions containing operators
  */
 
-abstract public class JOp {
+public abstract class JOp {
 
     private JOp() {
     }

--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/fmt/JStaticJavaFile.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/fmt/JStaticJavaFile.java
@@ -151,7 +151,7 @@ public final class JStaticJavaFile extends JResourceFile {
     /**
      * A {@link LineFilter} that combines two {@link LineFilter}s.
      */
-    public final static class ChainFilter implements LineFilter {
+    public static final class ChainFilter implements LineFilter {
         private final LineFilter first,second;
         public ChainFilter( LineFilter first, LineFilter second ) {
             this.first=first;

--- a/jaxb-ri/codemodel/codemodel/src/test/java/com/sun/codemodel/JModsTest.java
+++ b/jaxb-ri/codemodel/codemodel/src/test/java/com/sun/codemodel/JModsTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package com.sun.codemodel;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import java.lang.reflect.Modifier;
+
+import org.junit.Test;
+
+public class JModsTest {
+	static final int ALL_JMODS = JMod.PUBLIC | JMod.PROTECTED | JMod.PRIVATE
+			| JMod.ABSTRACT | JMod.STATIC | JMod.FINAL
+			| JMod.TRANSIENT | JMod.VOLATILE
+			| JMod.SYNCHRONIZED | JMod.NATIVE;
+
+	static final int ALL_REFLECT_MODS = Modifier.PUBLIC | Modifier.PROTECTED | Modifier.PRIVATE
+			| Modifier.ABSTRACT | Modifier.STATIC | Modifier.FINAL
+			| Modifier.TRANSIENT | Modifier.VOLATILE
+			| Modifier.SYNCHRONIZED | Modifier.NATIVE;
+
+	public JModsTest() {
+	}
+
+	@Test
+	public void testToString() {
+		assertArrayEquals(
+				Modifier.toString(ALL_REFLECT_MODS).split("\\s+"),
+				new JMods(ALL_JMODS).toString().split("\\s+"));
+	}
+}


### PR DESCRIPTION
This makes CodeModel and classes generated by it use the canonical modifier order documented in: [`java.lang.reflect.Modifier​::toString(int)`](https://docs.oracle.com/en/java/javase/19/docs/api/java.base/java/lang/reflect/Modifier.html#toString%28int%29).