### PR TITLE
feat(xjc): call postProcessModel with DTD models

### DIFF
--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/dtd/TDTDReader.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/dtd/TDTDReader.java
@@ -25,6 +25,7 @@ import com.sun.codemodel.JPackage;
 import com.sun.tools.xjc.AbortException;
 import com.sun.tools.xjc.ErrorReceiver;
 import com.sun.tools.xjc.Options;
+import com.sun.tools.xjc.Plugin;
 import com.sun.tools.xjc.model.CAttributePropertyInfo;
 import com.sun.tools.xjc.model.CBuiltinLeafInfo;
 import com.sun.tools.xjc.model.CClassInfo;
@@ -106,6 +107,11 @@ public class TDTDReader extends DTDHandlerBase
                 }
 
                 Ring.get(ModelChecker.class).check();
+
+                if( opts.activePlugins!=null ) {
+                    for (Plugin ma : opts.activePlugins)
+                        ma.postProcessModel(model, Ring.get(ErrorReceiver.class));
+                }
 
                 if(ef.hadError())   return null;
                 else                return model;

--- a/jaxb-ri/xjc/src/test/java/com/sun/tools/xjc/XjcDtdPluginTest.java
+++ b/jaxb-ri/xjc/src/test/java/com/sun/tools/xjc/XjcDtdPluginTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package com.sun.tools.xjc;
+
+import com.sun.codemodel.JCodeModel;
+import com.sun.tools.xjc.Driver.OptionsEx;
+import com.sun.tools.xjc.model.Model;
+import com.sun.tools.xjc.outline.Outline;
+import com.sun.tools.xjc.util.ErrorReceiverFilter;
+import org.junit.Assert;
+import org.junit.Test;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+public class XjcDtdPluginTest {
+    @Test
+    public void testCallPostProcessModelOnPlugin() {
+        final String dtdSchema = "<!ELEMENT hello (#PCDATA)>";
+
+        final OptionsEx opt = new OptionsEx();
+        opt.setSchemaLanguage(Language.DTD);
+        opt.compatibilityMode = Options.EXTENSION;
+
+        opt.addGrammar(
+            new InputSource(
+                new ByteArrayInputStream(
+                    dtdSchema.getBytes(StandardCharsets.UTF_8)
+                )
+            )
+        );
+
+        final Boolean[] wasPostProcessModelHookCalled = new Boolean[1];
+        wasPostProcessModelHookCalled[0] = Boolean.FALSE;
+
+        opt.activePlugins.add(new Plugin() {
+            @Override
+            public String getOptionName() {
+                return "XdebugPostProcessModel";
+            }
+
+            @Override
+            public String getUsage() {
+                return null;
+            }
+
+            @Override
+            public boolean run(
+                Outline outline,
+                Options opt,
+                ErrorHandler errorHandler) throws SAXException {
+                return true;
+            }
+
+            @Override
+            public void postProcessModel(Model model, ErrorHandler errorHandler) {
+                wasPostProcessModelHookCalled[0] = Boolean.TRUE;
+                super.postProcessModel(model, errorHandler);
+            }
+        });
+
+        ModelLoader.load(
+            opt,
+            new JCodeModel(),
+            new ErrorReceiverFilter()
+        );
+
+        Assert.assertTrue(
+            "DTD model did not call postProcessModel hook of the plugin",
+            wasPostProcessModelHookCalled[0]
+        );
+    }
+}


### PR DESCRIPTION
When code is generated from DTD schema, the hook function `postProcessModel` was not called. The code to do so was moved from global utility class to `BGMBuilder` class in the old code more than five years ago with the effect, that the hook was not called anymore for any other input than XSD.

A Junit 4 test is included.

* Eclipse account is created with same name as commiter email addres
* ECA is signed
