### PR TITLE
[#1695] Fix parsing of 'tru...' values inconsistent to true boolean

### DIFF
--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/DatatypeConverterImpl.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/DatatypeConverterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -213,7 +213,7 @@ public final class DatatypeConverterImpl implements DatatypeConverterInterface {
         char ch;
         boolean value = false;
 
-        if (literal.length() <= 0) {
+        if (len <= 0) {
             return null;
         }
 
@@ -236,10 +236,10 @@ public final class DatatypeConverterImpl implements DatatypeConverterInterface {
                     ch = literal.charAt(i++);
                 } while ((strTrue.charAt(strIndex++) == ch) && i < len && strIndex < 3);
 
-                if (strIndex == 3) {
+                if (strIndex == 3 && strTrue.charAt(strIndex - 1) == ch) {
                     value = true;
                 } else {
-                    return false;
+                    return null;
                 }
 //                    throw new IllegalArgumentException("String \"" + literal + "\" is not valid boolean value.");
 
@@ -251,10 +251,10 @@ public final class DatatypeConverterImpl implements DatatypeConverterInterface {
                 } while ((strFalse.charAt(strIndex++) == ch) && i < len && strIndex < 4);
 
 
-                if (strIndex == 4) {
+                if (strIndex == 4 && strFalse.charAt(strIndex - 1) == ch) {
                     value = false;
                 } else {
-                    return false;
+                    return null;
                 }
 //                    throw new IllegalArgumentException("String \"" + literal + "\" is not valid boolean value.");
 
@@ -262,9 +262,9 @@ public final class DatatypeConverterImpl implements DatatypeConverterInterface {
         }
 
         if (i < len) {
-            do {
-                ch = literal.charAt(i++);
-            } while (WhiteSpaceProcessor.isWhiteSpace(ch) && i < len);
+            while (i < len && WhiteSpaceProcessor.isWhiteSpace(literal.charAt(i))) {
+              i++;
+            }
         }
 
         if (i == len) {

--- a/jaxb-ri/runtime/impl/src/test/java/org/glassfish/jaxb/runtime/DatatypeConverterImplTest.java
+++ b/jaxb-ri/runtime/impl/src/test/java/org/glassfish/jaxb/runtime/DatatypeConverterImplTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023, 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package org.glassfish.jaxb.runtime;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DatatypeConverterImplTest {
+
+    @Test
+    public void testParseBoolean() {
+        Assert.assertEquals(null, DatatypeConverterImpl._parseBoolean(null));
+        Assert.assertEquals(null, DatatypeConverterImpl._parseBoolean(""));
+        Assert.assertEquals(null, DatatypeConverterImpl._parseBoolean("11"));
+        Assert.assertEquals(null, DatatypeConverterImpl._parseBoolean("1A"));
+        Assert.assertEquals(null, DatatypeConverterImpl._parseBoolean("non"));
+        Assert.assertEquals(null, DatatypeConverterImpl._parseBoolean("fals"));
+        Assert.assertEquals(null, DatatypeConverterImpl._parseBoolean("falses"));
+        Assert.assertEquals(null, DatatypeConverterImpl._parseBoolean("false s"));
+        Assert.assertEquals(null, DatatypeConverterImpl._parseBoolean("falst"));
+        Assert.assertEquals(null, DatatypeConverterImpl._parseBoolean("tru"));
+        Assert.assertEquals(null, DatatypeConverterImpl._parseBoolean("trux"));
+        Assert.assertEquals(null, DatatypeConverterImpl._parseBoolean("truu"));
+        Assert.assertEquals(null, DatatypeConverterImpl._parseBoolean("truxx"));
+        Assert.assertEquals(null, DatatypeConverterImpl._parseBoolean("truth"));
+        Assert.assertEquals(null, DatatypeConverterImpl._parseBoolean("truelle"));
+        Assert.assertEquals(null, DatatypeConverterImpl._parseBoolean("truec"));
+        Assert.assertEquals(null, DatatypeConverterImpl._parseBoolean("true c"));
+        Assert.assertEquals(null, DatatypeConverterImpl._parseBoolean("oui"));
+
+        Assert.assertEquals(false, DatatypeConverterImpl._parseBoolean("0"));
+        Assert.assertEquals(false, DatatypeConverterImpl._parseBoolean(" 0"));
+        Assert.assertEquals(false, DatatypeConverterImpl._parseBoolean(" 0 "));
+        Assert.assertEquals(false, DatatypeConverterImpl._parseBoolean("0 "));
+        Assert.assertEquals(true, DatatypeConverterImpl._parseBoolean("1"));
+        Assert.assertEquals(true, DatatypeConverterImpl._parseBoolean(" 1"));
+        Assert.assertEquals(true, DatatypeConverterImpl._parseBoolean(" 1 "));
+        Assert.assertEquals(true, DatatypeConverterImpl._parseBoolean("1 "));
+        Assert.assertEquals(false, DatatypeConverterImpl._parseBoolean("false"));
+        Assert.assertEquals(false, DatatypeConverterImpl._parseBoolean(" false"));
+        Assert.assertEquals(false, DatatypeConverterImpl._parseBoolean("false "));
+        Assert.assertEquals(false, DatatypeConverterImpl._parseBoolean(" false "));
+        Assert.assertEquals(true, DatatypeConverterImpl._parseBoolean("true"));
+        Assert.assertEquals(true, DatatypeConverterImpl._parseBoolean(" true"));
+        Assert.assertEquals(true, DatatypeConverterImpl._parseBoolean("true "));
+        Assert.assertEquals(true, DatatypeConverterImpl._parseBoolean(" true "));
+    }
+}


### PR DESCRIPTION
Fixes #1695 
Adding test case to validate `_parseBoolean` function