### PR TITLE
Rework stackoverflow because xsd schemagen have missing elements

### DIFF
--- a/jaxb-ri/runtime/impl/src/test/java/org/glassfish/jaxb/runtime/v2/schemagen/Foo.java
+++ b/jaxb-ri/runtime/impl/src/test/java/org/glassfish/jaxb/runtime/v2/schemagen/Foo.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package org.glassfish.jaxb.runtime.v2.schemagen;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "", propOrder = {"fooObject"})
+@XmlRootElement(name = "Foo")
+public class Foo {
+    protected List<Foo> fooObject;
+
+    public List<Foo> getFooObject() {
+        if (fooObject == null) {
+            fooObject = new ArrayList<Foo>();
+        }
+        return this.fooObject;
+    }
+}

--- a/jaxb-ri/runtime/impl/src/test/java/org/glassfish/jaxb/runtime/v2/schemagen/XmlSchemaGeneratorTest.java
+++ b/jaxb-ri/runtime/impl/src/test/java/org/glassfish/jaxb/runtime/v2/schemagen/XmlSchemaGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -16,11 +16,15 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.SchemaOutputResolver;
+import jakarta.xml.bind.MarshalException;
 import javax.xml.transform.Result;
 import javax.xml.transform.stream.StreamResult;
 
@@ -31,7 +35,21 @@ public class XmlSchemaGeneratorTest extends TestCase {
     public static void main(String[] args) {
         TestRunner.run(XmlSchemaGeneratorTest.class);
     }
-    
+
+    public void testStackoverflow() throws Exception {
+        Map<String, Object> properties = new HashMap<>();
+        JAXBContext c = JAXBContext.newInstance(new Class[] {Foo.class}, properties);
+        Foo foo = new Foo();
+        foo.getFooObject().add(foo);
+        StringWriter sw = new StringWriter();
+        try {
+            c.createMarshaller().marshal(foo, sw);
+            fail("It is expected to catch MarshalException");
+        } catch (MarshalException e) {
+            // Expected
+        }
+    }
+
     public void test2() throws Exception {
         try {
             JAXBContext context = JAXBContext.newInstance(NSParent.class);


### PR DESCRIPTION
Initially stackoverflow was not possible running schemagen. Later, this commit was added and it made it possible:
https://github.com/javaee/jaxb-v2/commit/ccaef7f6b3c47149a70edc1cf5dde956b8efdd5c

Then, there was a try to fix the stackoverflow, but it makes some mistakes in the generated xsd (see attachments and search for 'addressInformation'  [correct.xsd.txt](https://github.com/eclipse-ee4j/jaxb-ri/files/12584088/correct.xsd.txt)
[notCorrect.xsd.txt](https://github.com/eclipse-ee4j/jaxb-ri/files/12584089/notCorrect.xsd.txt)):
https://github.com/javaee/jaxb-v2/commit/62ae6d3cb7f784dae398a0c04759cbafed7e4cfc

This PR fixes the XSD and it does not throw stackoverflow error.

I tried to add a test for schemagen, but I didn't find the way. There are some issues if you try to invoke directly com.sun.tools.jxc.SchemaGenerator. You can verify there is no stackoverflow running the next:
```
cd  jaxb-ri
mvn clean install
java -cp runtime/impl/target/test-classes:bundles/ri/target/stage/jaxb-ri/mod/* com.sun.tools.jxc.SchemaGenerator -d target runtime/impl/src/test/java/org/glassfish/jaxb/runtime/v2/schemagen/Foo.java
```
It will print the next:
```
Note: Writing /home/jbescos/workspace/jaxb-ri/jaxb-ri/target/schema1.xsd
warning: Error occured during schema generation, however the schema could be generated. There is a circular dependency on an element in your schema: ClassInfo(org.glassfish.jaxb.runtime.v2.schemagen.Foo) -> ClassInfo(org.glassfish.jaxb.runtime.v2.schemagen.Foo) This element is not defined as global element and thus references were not generated and the type has been inlined where possible. To allow references for the type, add XmlRootElement annotation to your type definition class.
warning: 
```
It does not fail the execution, but it prints a warning and it will generate the xsd in this way:
```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<xs:schema version="1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema">

  <xs:element name="Foo">
    <xs:complexType>
      <xs:sequence>
        <xs:element name="fooObject" nillable="true" minOccurs="0" maxOccurs="unbounded"/>
      </xs:sequence>
    </xs:complexType>
  </xs:element>
</xs:schema>

```
