### PR TITLE
[#1730] Fix NPE in generated from RNC

### DIFF
--- a/jaxb-ri/docs/release-documentation/src/docbook/jaxb-changelog.xml
+++ b/jaxb-ri/docs/release-documentation/src/docbook/jaxb-changelog.xml
@@ -30,6 +30,9 @@
             <listitem><para>Bug fixes:
                 <itemizedlist>
                     <listitem><para>
+                        <link xlink:href="https://github.com/eclipse-ee4j/jaxb-ri/issues/1730">#1730</link>: Error while parsing rnc
+                    </para></listitem>
+                    <listitem><para>
                         <link xlink:href="https://github.com/eclipse-ee4j/jaxb-ri/issues/1783">#1783</link>: Dependency Exclusion for stax-ex in jaxb-bom is incompatible with dependency:analyze-dep-mgt
                     </para></listitem>
                     <listitem><para>

--- a/jaxb-ri/external/rngom/src/main/java/com/sun/tools/rngom/digested/DSchemaBuilderImpl.java
+++ b/jaxb-ri/external/rngom/src/main/java/com/sun/tools/rngom/digested/DSchemaBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2011
+ * Copyright (C) 2004-2024
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -192,7 +192,7 @@ public class DSchemaBuilderImpl implements SchemaBuilder
     }
 
     public CommentListImpl makeCommentList() {
-        return null;
+        return new CommentListImpl();
     }
 
     public DPattern makeErrorPattern() {


### PR DESCRIPTION
Fixes #1730
The faulty code with NPE was returning `null` instead of `new CommentListImpl()`
Fixing NPE even if this returned class has /TODO/ inside with nothing done on `addComents` method.