### PR TITLE
[#1779] add globalBindings nameXmlTransform option

### DIFF
--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/BGMBuilder.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/BGMBuilder.java
@@ -573,10 +573,17 @@ public class BGMBuilder extends BindingComponent {
 
         name = getNameConverter().toClassName(name);
 
-        if( owner!=null ) {
+        if (owner != null) {
             BISchemaBinding sb = getBindInfo(owner).get(BISchemaBinding.class);
 
-            if(sb!=null)    name = sb.mangleClassName(name,comp);
+            String newName = name;
+            if (sb != null) {
+                newName = sb.mangleClassName(name, comp);
+            }
+            if (newName.equals(name) && globalBinding != null) {
+                newName = globalBinding.mangleClassName(name, comp);
+            }
+            name = newName;
         }
 
         return name;

--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/DefaultClassBinder.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/DefaultClassBinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -159,12 +159,20 @@ final class DefaultClassBinder implements ClassBinder
                 className = "Type";
             } else {
                 // since the parent element isn't bound to a type, merge the customizations associated to it, too.
-//                custs = CCustomizations.merge( custs, builder.getBindInfo(type.getScope()).toCustomizationList());
+                // custs = CCustomizations.merge( custs, builder.getBindInfo(type.getScope()).toCustomizationList());
                 className = builder.getNameConverter().toClassName(element.getName());
 
                 BISchemaBinding sb = builder.getBindInfo(
                     type.getOwnerSchema() ).get(BISchemaBinding.class);
-                if(sb!=null)    className = sb.mangleAnonymousTypeClassName(className);
+
+                String newClassName = className;
+                if (sb != null) {
+                    newClassName = sb.mangleAnonymousTypeClassName(className);
+                }
+                if (newClassName.equals(className) && getGlobalBinding() != null) {
+                    newClassName = getGlobalBinding().mangleAnonymousTypeClassName(className);
+                }
+                className = newClassName;
                 scope = selector.getClassScope();
             }
 

--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/bindinfo/BIGlobalBinding.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/bindinfo/BIGlobalBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -15,6 +15,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import com.sun.xml.xsom.XSAttributeDecl;
+import com.sun.xml.xsom.XSComponent;
+import com.sun.xml.xsom.XSElementDecl;
+import com.sun.xml.xsom.XSModelGroup;
+import com.sun.xml.xsom.XSModelGroupDecl;
+import com.sun.xml.xsom.XSType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlEnumValue;
@@ -54,7 +60,6 @@ import com.sun.xml.xsom.XSSimpleType;
  */
 @XmlRootElement(name="globalBindings")
 public final class BIGlobalBinding extends AbstractDeclarationImpl {
-    
 
     /**
      * Gets the name converter that will govern the {@code XML -> Java}
@@ -358,6 +363,36 @@ public final class BIGlobalBinding extends AbstractDeclarationImpl {
         this.serializable = s;
     }
 
+    @XmlElement
+    private NameRules nameXmlTransform = new NameRules();
+
+    /**
+     * Transforms the default name produced from XML name
+     * by following the customization.
+     *
+     * This shouldn't be applied to a class name specified
+     * by a customization.
+     *
+     * @param cmp
+     *      The schema component from which the default name is derived.
+     */
+    public String mangleClassName( String name, XSComponent cmp ) {
+        if( cmp instanceof XSType)
+            return nameXmlTransform.typeName.mangle(name);
+        if( cmp instanceof XSElementDecl)
+            return nameXmlTransform.elementName.mangle(name);
+        if( cmp instanceof XSAttributeDecl)
+            return nameXmlTransform.attributeName.mangle(name);
+        if( cmp instanceof XSModelGroup || cmp instanceof XSModelGroupDecl)
+            return nameXmlTransform.modelGroupName.mangle(name);
+
+        // otherwise no modification
+        return name;
+    }
+
+    public String mangleAnonymousTypeClassName( String name ) {
+        return nameXmlTransform.anonymousTypeName.mangle(name);
+    }
 
 
     private static final class TypeSubstitutionElement {

--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/bindinfo/BISchemaBinding.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/bindinfo/BISchemaBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -13,7 +13,6 @@ package com.sun.tools.xjc.reader.xmlschema.bindinfo;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import jakarta.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
 
 import com.sun.tools.xjc.reader.Const;
@@ -32,23 +31,6 @@ import com.sun.xml.xsom.XSType;
  */
 @XmlRootElement(name="schemaBindings")
 public final class BISchemaBinding extends AbstractDeclarationImpl {
-
-    /**
-     * Name conversion rules. All defaults to {@link BISchemaBinding#defaultNamingRule}.
-     */
-    @XmlType(propOrder={})
-    private static final class NameRules {
-        @XmlElement
-        NamingRule typeName = defaultNamingRule;
-        @XmlElement
-        NamingRule elementName = defaultNamingRule;
-        @XmlElement
-        NamingRule attributeName = defaultNamingRule;
-        @XmlElement
-        NamingRule modelGroupName = defaultNamingRule;
-        @XmlElement
-        NamingRule anonymousTypeName = defaultNamingRule;
-    }
 
     @XmlElement
     private NameRules nameXmlTransform = new NameRules();
@@ -70,39 +52,6 @@ public final class BISchemaBinding extends AbstractDeclarationImpl {
      */
     @XmlAttribute(name="map")
     public boolean map = true;
-
-    /**
-     * Default naming rule, that doesn't change the name.
-     */
-    private static final NamingRule defaultNamingRule = new NamingRule("","");
-    
-
-    /**
-     * Default naming rules of the generated interfaces.
-     * 
-     * It simply adds prefix and suffix to the name, but
-     * the caller shouldn't care how the name mangling is
-     * done.
-     */
-    public static final class NamingRule {
-        @XmlAttribute
-        private String prefix = "";
-        @XmlAttribute
-        private String suffix = "";
-        
-        public NamingRule( String _prefix, String _suffix ) {
-            this.prefix = _prefix;
-            this.suffix = _suffix;
-        }
-
-        public NamingRule() {
-        }
-
-        /** Changes the name according to the rule. */
-        public String mangle( String originalName ) {
-            return prefix+originalName+suffix;
-        }
-    }
 
     /**
      * Default constructor.

--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/bindinfo/NameRules.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/bindinfo/NameRules.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package com.sun.tools.xjc.reader.xmlschema.bindinfo;
+
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlType;
+
+/**
+ * Name conversion rules. All defaults to {@link NameRules#defaultNamingRule}.
+ */
+@XmlType(propOrder={})
+public final class NameRules {
+    @XmlElement
+    NamingRule typeName = defaultNamingRule;
+    @XmlElement
+    NamingRule elementName = defaultNamingRule;
+    @XmlElement
+    NamingRule attributeName = defaultNamingRule;
+    @XmlElement
+    NamingRule modelGroupName = defaultNamingRule;
+    @XmlElement
+    NamingRule anonymousTypeName = defaultNamingRule;
+
+    /**
+     * Default naming rule, that doesn't change the name.
+     */
+    private static final NamingRule defaultNamingRule = new NamingRule("", "");
+
+    /**
+     * Default naming rules of the generated interfaces.
+     *
+     * It simply adds prefix and suffix to the name, but
+     * the caller shouldn't care how the name mangling is
+     * done.
+     */
+    public static final class NamingRule {
+        @XmlAttribute
+        private String prefix = "";
+        @XmlAttribute
+        private String suffix = "";
+
+        public NamingRule(String _prefix, String _suffix) {
+            this.prefix = _prefix;
+            this.suffix = _suffix;
+        }
+
+        public NamingRule() {
+        }
+
+        /** Changes the name according to the rule. */
+        public String mangle(String originalName) {
+            return prefix + originalName + suffix;
+        }
+    }
+}

--- a/jaxb-ri/xjc/src/main/schemas/com/sun/tools/xjc/reader/xmlschema/bindinfo/binding.xsd
+++ b/jaxb-ri/xjc/src/main/schemas/com/sun/tools/xjc/reader/xmlschema/bindinfo/binding.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -59,6 +59,7 @@
         <xs:element ref="xjc:noUnmarshaller"/>
         <xs:element ref="xjc:noValidator"/>
         <xs:element ref="xjc:noValidatingUnmarshaller"/>
+        <xs:element ref="jaxb:nameXmlTransform"/>
       </xs:choice>
       <xs:attribute name="underscoreBinding">
         <xs:simpleType>


### PR DESCRIPTION
Fixes #1779 

This PR proposal is adding a new `nameXmlTransform` element in `globalBindings`, allowing users to globally define name transformation with no more the need of defining this section for each XSD in XJC context