### PR TITLE
Fixing GH-737 : compute class type with generics handle

### DIFF
--- a/jaxb-ri/docs/release-documentation/src/docbook/jaxb-changelog.xml
+++ b/jaxb-ri/docs/release-documentation/src/docbook/jaxb-changelog.xml
@@ -30,6 +30,12 @@
             <listitem><para>Bug fixes:
                 <itemizedlist>
                     <listitem><para>
+                        <link xlink:href="https://github.com/eclipse-ee4j/jaxb-ri/issues/209">#209</link>: Schema-driven XmlAdapter using xjc:javaType
+                    </para></listitem>
+                    <listitem><para>
+                        <link xlink:href="https://github.com/eclipse-ee4j/jaxb-ri/issues/737">#737</link>: xjc:javaType does not handle generic types
+                    </para></listitem>
+                    <listitem><para>
                         <link xlink:href="https://github.com/eclipse-ee4j/jaxb-ri/issues/1783">#1783</link>: Dependency Exclusion for stax-ex in jaxb-bom is incompatible with dependency:analyze-dep-mgt
                     </para></listitem>
                     <listitem><para>


### PR DESCRIPTION
Fixes #737
Fixes #209 (to check if it was dependant of #737)

Add generic handle in xjc:javaType
The `name` tag should be of the form : `name="java.util.List&lt;java.lang.String&gt;"` for expected `List<String>`

Need also to provide good `adapter` that implements the wanted `XmlAdapter<String, ExpectedType>` where `ExpectedType` with the example would be `List<String>` like [CommaDelimitedStringAdapter](https://github.com/highsource/jaxb-tools/blob/8285be68a1aeb4c2ab18454d0f9280cca328a8b0/jaxb-plugins-parent/jaxb-plugins-runtime/src/main/java/org/jvnet/jaxb/xml/bind/annotation/adapters/CommaDelimitedStringAdapter.java)