### PR TITLE
#1783: Dependency Exclusion for stax-ex in jaxb-bom is incompatible with dependency:analyze-dep-mgt

### DIFF
--- a/jaxb-ri/boms/bom/pom.xml
+++ b/jaxb-ri/boms/bom/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2013, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2013, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -125,12 +125,6 @@
                 <artifactId>stax-ex</artifactId>
                 <version>${stax-ex.version}</version>
                 <classifier>sources</classifier>
-                <exclusions>
-                    <exclusion>
-                        <groupId>jakarta.activation</groupId>
-                        <artifactId>jakarta.activation-api</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.fastinfoset</groupId>

--- a/jaxb-ri/docs/release-documentation/src/docbook/jaxb-changelog.xml
+++ b/jaxb-ri/docs/release-documentation/src/docbook/jaxb-changelog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -29,6 +29,9 @@
         <itemizedlist>
             <listitem><para>Bug fixes:
                 <itemizedlist>
+                    <listitem><para>
+                        <link xlink:href="https://github.com/eclipse-ee4j/jaxb-ri/issues/1783">#1783</link>: Dependency Exclusion for stax-ex in jaxb-bom is incompatible with dependency:analyze-dep-mgt
+                    </para></listitem>
                     <listitem><para>
                         <link xlink:href="https://github.com/eclipse-ee4j/jaxb-dtd-parser/issues/39">dtd-parser #39</link>: Parser parses #IMPLIED use attributes as NORMAL (and vice versa)
                     </para></listitem>


### PR DESCRIPTION
fixes #1783 