### PR TITLE
Suppress episode file header comment when "-no-header" is set

### DIFF
--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/addon/episode/PluginImpl.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/addon/episode/PluginImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -148,7 +148,9 @@ public class PluginImpl extends Plugin {
             else
                 bindings._namespace(Const.JAXB_NSURI,"");
             bindings.version("3.0");
-            bindings._comment("\n\n"+opt.getPrologComment()+"\n  ");
+            if (!opt.noFileHeader) {
+                bindings._comment("\n\n"+opt.getPrologComment()+"\n  ");
+            }
 
             // generate listing per schema
             for (Map.Entry<XSSchema,PerSchemaOutlineAdaptors> e : perSchema.entrySet()) {


### PR DESCRIPTION
The header comment generated for episode files contains a timestamp with the date of generation. This causes problems for tools that do a binary comparison of artifacts, in order to check for e.g. a required version increment.