### PR TITLE
Fix issue #1819 incorrect enum value name generation with leading digits

### DIFF
--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/SimpleTypeBuilder.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/SimpleTypeBuilder.java
@@ -674,6 +674,8 @@ public final class SimpleTypeBuilder extends BindingComponent {
 
                 if(name==null) {
                     StringBuilder sb = new StringBuilder();
+                    if (factValue.length()>0 && !Character.isJavaIdentifierStart(facetValue.charAt(0)))
+                        sb.append('_'); //Otherwise enum constants starting with digits will be renamed to VALUE_x
                     for( int i=0; i<facetValue.length(); i++) {
                         char ch = facetValue.charAt(i);
                         if(Character.isJavaIdentifierPart(ch))


### PR DESCRIPTION
Currently any charcter complying with `isJavaIdentifierPart` but not `isJavaIdentifierStart` (e.g. digits) at the beginning of the name of an enum value will make `buildCEnumConstants` return null (as `isJavaIdentifier` fails) which causes the enums values to be named `VALUE_x` (method is called again but with `needsToGenerateMemberName`). 

This PR fixes that by checking whether the first character of an enum value name complies with `isJavaIdentifierStart`, if not an underscore will be added to the `StringBuilder `that builds the name of the value. As that check is executed before the normal name generation loop that underscore is the first char of the `StringBuilder` and acts a prefix to the name. That behaviour is consistent with the one found in other places of the java code generation, for example a package called `12` will be renamed to `_12`.