### PR TITLE
[#1826] XJC should preserve some XML entities in generated JavaDoc

### DIFF
--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JDocComment.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JDocComment.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -54,9 +55,15 @@ public class JDocComment extends JCommentPart implements JGenerable {
         this.owner = owner;
     }
 
-        @Override
+    @Override
     public JDocComment append(Object o) {
         add(o);
+        return this;
+    }
+
+    @Override
+    public JDocComment appendXML(String s) {
+        super.appendXML(s);
         return this;
     }
 

--- a/jaxb-ri/codemodel/codemodel/src/test/java/com/sun/codemodel/tests/JCommentTest.java
+++ b/jaxb-ri/codemodel/codemodel/src/test/java/com/sun/codemodel/tests/JCommentTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -43,5 +44,29 @@ public class JCommentTest extends TestCase {
         assertTrue(generatedClass.contains("<b>"));
         assertTrue(generatedClass.contains("</p>"));
         assertFalse(generatedClass.contains("&"));
+    }
+
+    /**
+     * This should produce the following javadoc :<br><br>
+     * Age &lt;&gt; 18 &amp; age &lt;&gt; 21 &#064;home
+     */
+    public void testJavadocXML() throws Throwable {
+        JCodeModel model = new JCodeModel();
+        String className = "gh1826.JavadocTest";
+        JDefinedClass cls = model._class(className, ClassType.CLASS);
+        JDocComment comment = cls.javadoc();
+        comment.appendXML("Age <> 18 & age <> 21 @home");
+
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        OutputStreamCodeWriter fileCodeWriter = new OutputStreamCodeWriter(os, "UTF-8");
+        model.build(fileCodeWriter);
+
+        String generatedClass = os.toString(StandardCharsets.UTF_8);
+        System.out.println(generatedClass);
+        assertFalse(generatedClass.contains("<"));
+        assertFalse(generatedClass.contains(">"));
+        assertFalse(generatedClass.contains("@"));
+        assertTrue(generatedClass.contains("&amp;"));
+        assertTrue(generatedClass.contains("&#064;"));
     }
 }

--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/generator/bean/BeanGenerator.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/generator/bean/BeanGenerator.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -556,7 +557,7 @@ public final class BeanGenerator implements Outline {
         }
 
         // generate some class level javadoc
-        cc.ref.javadoc().append(target.javadoc);
+        cc.ref.javadoc().appendXML(target.javadoc);
 
         cc._package().objectFactoryGenerator().populate(cc);
     }
@@ -615,7 +616,7 @@ public final class BeanGenerator implements Outline {
 
         type = getClassFactory().createClass(
                 getContainer(e.parent, EXPOSED), e.shortName, e.getLocator(), ClassType.ENUM);
-        type.javadoc().append(e.javadoc);
+        type.javadoc().appendXML(e.javadoc);
 
         return new EnumOutline(e, type) {
 
@@ -682,7 +683,7 @@ public final class BeanGenerator implements Outline {
 
             // set javadoc
             if (mem.javadoc != null) {
-                constRef.javadoc().append(mem.javadoc);
+                constRef.javadoc().appendXML(mem.javadoc);
             }
 
             eo.constants.add(new EnumConstantOutline(mem, constRef) {

--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/generator/bean/field/AbstractFieldWithVar.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/generator/bean/field/AbstractFieldWithVar.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -47,7 +48,7 @@ abstract class AbstractFieldWithVar extends AbstractField {
             getFieldType(), prop.getName(false) );
 
         if (prop.javadoc != null && prop.javadoc.length() > 0) {
-            field.javadoc().add(prop.javadoc);
+            field.javadoc().appendXML(prop.javadoc);
         }
 
         annotate(field);

--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/generator/bean/field/AbstractListField.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/generator/bean/field/AbstractListField.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -99,7 +100,7 @@ abstract class AbstractListField extends AbstractField {
             field.init(newCoreList());
 
         if (prop.javadoc != null && prop.javadoc.length() > 0) {
-            field.javadoc().add(prop.javadoc);
+            field.javadoc().appendXML(prop.javadoc);
         }
 
         annotate(field);

--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/generator/bean/field/ArrayField.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/generator/bean/field/ArrayField.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -102,7 +103,7 @@ final class ArrayField extends AbstractListField {
         // }
         $getAll = writer.declareMethod( exposedType.array(),"get"+prop.getName(true));
         if (prop.javadoc != null && prop.javadoc.length() > 0) {
-            writer.javadoc().append(prop.javadoc).append("\n\n");
+            writer.javadoc().appendXML(prop.javadoc).append("\n\n");
         }
         body = $getAll.body();
 
@@ -129,7 +130,7 @@ final class ArrayField extends AbstractListField {
         $get.body()._if(acc.ref(true).eq(JExpr._null()))._then()
             ._throw(JExpr._new(codeModel.ref(IndexOutOfBoundsException.class)));
 
-        writer.javadoc().append(prop.javadoc);
+        writer.javadoc().appendXML(prop.javadoc);
         $get.body()._return(acc.ref(true).component($idx));
 
         writer.javadoc().addReturn().append("one of\n").append(returnTypes);
@@ -156,7 +157,7 @@ final class ArrayField extends AbstractListField {
             codeModel.VOID,
             "set"+prop.getName(true));
 
-        writer.javadoc().append(prop.javadoc);
+        writer.javadoc().appendXML(prop.javadoc);
         $value = writer.addParameter(exposedType.array(),"values");
 
         $setAll.body()._if( $value.eq(JExpr._null()) )._then()
@@ -189,7 +190,7 @@ final class ArrayField extends AbstractListField {
         $idx = writer.addParameter( codeModel.INT, "idx" );
         $value = writer.addParameter( exposedType, "value" );
 
-        writer.javadoc().append(prop.javadoc);
+        writer.javadoc().appendXML(prop.javadoc);
 
         body = $set.body();
         body._return( JExpr.assign(acc.ref(true).component($idx),

--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/generator/bean/field/ConstField.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/generator/bean/field/ConstField.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -57,7 +58,7 @@ final class ConstField extends AbstractField {
         
         // Do not append empty javadoc.
         if ( (prop.javadoc != null) && (prop.javadoc.length() > 0) )
-            $ref.javadoc().append(prop.javadoc);
+            $ref.javadoc().appendXML(prop.javadoc);
 
         annotate($ref);
     }

--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/generator/bean/field/ContentListField.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/generator/bean/field/ContentListField.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -101,7 +102,7 @@ public class ContentListField extends AbstractListField {
         // }
         $get = writer.declareMethod(listT,"get"+prop.getName(true));
         if (prop.javadoc != null && prop.javadoc.length() > 0) {
-            writer.javadoc().append(prop.javadoc).append("\n\n");
+            writer.javadoc().appendXML(prop.javadoc).append("\n\n");
         }
         JBlock block = $get.body();
         fixNullRef(block);  // avoid using an internal getter

--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/generator/bean/field/NoExtendedContentField.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/generator/bean/field/NoExtendedContentField.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -104,7 +105,7 @@ public class NoExtendedContentField extends AbstractListField {
         // }
         $get = writer.declareMethod(listT,"get"+prop.getName(true));
         if (prop.javadoc != null && prop.javadoc.length() > 0) {
-            writer.javadoc().append(prop.javadoc).append("\n\n");
+            writer.javadoc().appendXML(prop.javadoc).append("\n\n");
         }
         JBlock block = $get.body();
         fixNullRef(block);  // avoid using an internal getter

--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/generator/bean/field/SingleField.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/generator/bean/field/SingleField.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -94,11 +95,11 @@ public class SingleField extends AbstractFieldWithVar {
         }
 
         JMethod $get = writer.declareMethod( getterType,getGetterMethod() );
-        String javadoc = prop.javadoc;
-        if(javadoc.length()==0)
-            javadoc = Messages.DEFAULT_GETTER_JAVADOC.format(nc.toVariableName(prop.getName(true)));
-        writer.javadoc().append(javadoc);
-
+        if (prop.javadoc.isEmpty()) {
+            writer.javadoc().append(Messages.DEFAULT_GETTER_JAVADOC.format(nc.toVariableName(prop.getName(true))));
+        } else {
+            writer.javadoc().appendXML(prop.javadoc);
+        }
 
         if(defaultValue==null) {
             $get.body()._return(ref());

--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/generator/bean/field/UnboxedField.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/generator/bean/field/UnboxedField.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -62,10 +63,11 @@ public class UnboxedField extends AbstractFieldWithVar {
         //     return value;
         // }
         JMethod $get = writer.declareMethod( ptype, getGetterMethod() );
-        String javadoc = prop.javadoc;
-        if(javadoc.length()==0)
-            javadoc = Messages.DEFAULT_GETTER_JAVADOC.format(nc.toVariableName(prop.getName(true)));
-        writer.javadoc().append(javadoc);
+        if (prop.javadoc.isEmpty()) {
+            writer.javadoc().append(Messages.DEFAULT_GETTER_JAVADOC.format(nc.toVariableName(prop.getName(true))));
+        } else {
+            writer.javadoc().appendXML(prop.javadoc);
+        }
 
         $get.body()._return(ref());
 

--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/generator/bean/field/UntypedListField.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/generator/bean/field/UntypedListField.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -99,7 +100,7 @@ public class UntypedListField extends AbstractListField {
         // }
         $get = writer.declareMethod(listT,"get"+prop.getName(true));
         if (prop.javadoc != null && prop.javadoc.length() > 0) {
-            writer.javadoc().append(prop.javadoc).append("\n\n");
+            writer.javadoc().appendXML(prop.javadoc).append("\n\n");
         }
         JBlock block = $get.body();
         fixNullRef(block);  // avoid using an internal getter

--- a/jaxb-ri/xjc/src/test/resources/com/sun/tools/xjc/resources/simple.xsd
+++ b/jaxb-ri/xjc/src/test/resources/com/sun/tools/xjc/resources/simple.xsd
@@ -1,6 +1,7 @@
 <!--
 
     Copyright (c) 2017, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -11,6 +12,49 @@
 -->
 
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <xsd:element name="e" type="xsd:string"/>
+    <xsd:element name="e" type="xsd:string" />
+
+    <xsd:complexType name="testEscapeJavadoc">
+        <xsd:annotation>
+            <xsd:documentation>Test escape Javadoc &lt; &gt; &amp; &apos; &quot; */ Hello World</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="lt" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation>Test escape &lt;</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="gt" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation>Test escape &gt;</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="amp" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation>Test escape &amp;</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="listLtGtAmp" type="xsd:string" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Test escape list &lt; &amp; &gt;</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="apos" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation>Test not escape &apos;</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="quot" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation>Test not escape &quot;</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="comment" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation>Test escape */</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
 </xsd:schema>
 


### PR DESCRIPTION
Fixes #1826 

Needs #1842 first to be merged since javadoc fails on list attributes (build will fail for now)

This will replace `<` `>` and `&` documentation from XML in javadoc with `&lt;` `&gt;` and `&amp;`