### PR TITLE
[#1836] exclude META-INF/services from source jar in osgi

### DIFF
--- a/jaxb-ri/bundles/osgi/osgi/pom.xml
+++ b/jaxb-ri/bundles/osgi/osgi/pom.xml
@@ -2,6 +2,7 @@
 <!--
 
     Copyright (c) 2013, 2023 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -319,6 +320,20 @@
                             </instructions>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>bundle-manifest-sources</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                        <configuration>
+                            <manifestLocation>${project.build.directory}/source-manifest</manifestLocation>
+                            <instructions>
+                                <Bundle-SymbolicName>${project.groupId}.${project.artifactId}.source</Bundle-SymbolicName>
+                                <Eclipse-SourceBundle>${project.groupId}.${project.artifactId};version="${project.version}"</Eclipse-SourceBundle>
+                            </instructions>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 
@@ -384,6 +399,17 @@
                         ${project.basedir}/../../../runtime/impl/exclude-runtime.xml,
                         ${project.basedir}/../../../jxc/exclude-jxc.xml
                     </excludeFilterFile>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.directory}/source-manifest/MANIFEST.MF</manifestFile>
+                    </archive>
+                    <excludes>META-INF/services/**</excludes>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Fixes #1836 

Configures maven-source-plugin to exclude the `META-INF/services` folder in OSGI bundle