### PR TITLE
fix #1645 by fixing incorrect loop calculation

### DIFF
--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/output/IndentingUTF8XmlOutput.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/output/IndentingUTF8XmlOutput.java
@@ -109,13 +109,13 @@ public final class IndentingUTF8XmlOutput extends UTF8XmlOutput {
 
     private void printIndent() throws IOException {
         write('\n');
-        int i = depth%8;
+        int i = depth & 0x7;    // int i = depth%8; // for any buffer length of 2 power n the modulo can be written as bit-and ((2 power n) - 1)
 
         write( indent8.buf, 0, i*unitLen );
 
-        i>>=3;  // really i /= 8;
+        i = depth>>3; // i>>=3;  // really i /= 8; **Bug** i only contains values between 0 and 7 (depth % 8). dividing by 8 will always be zero. 
 
-        for( ; i>0; i-- )
+        for( ; i>0; --i )
             indent8.write(this);
     }
 


### PR DESCRIPTION
Replaced modulo with a more performant bit-and, and corrected the incorrect calculation of complete indentation repetitions in line 116.

A longer explanation is included in the comment linked below.
https://github.com/eclipse-ee4j/jaxb-ri/issues/1645#issuecomment-3167962780