### PR TITLE
[#1788] ignore bindings file on schemaLocation="*" + test case

### DIFF
--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/internalizer/Internalizer.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/internalizer/Internalizer.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -171,9 +172,14 @@ class Internalizer {
             String schemaLocation = bindings.getAttribute("schemaLocation");
 
             // enhancement - schemaLocation="*" = bind to all schemas..
-            if(schemaLocation.equals("*")) {
+            if("*".equals(schemaLocation)) {
                 for(String systemId : forest.listSystemIDs()) {
                     result.computeIfAbsent(bindings, k -> new ArrayList<>());
+                    Element doc = forest.get(systemId).getDocumentElement();
+                    if (Const.JAXB_NSURI.equals(doc.getNamespaceURI())) {
+                        // this isn't a schema, so do apply bindings here or that will fail
+                        continue;
+                    }
                     result.get(bindings).add(forest.get(systemId).getDocumentElement());
 
                     Element[] children = DOMUtils.getChildElements(bindings, Const.JAXB_NSURI, "bindings");

--- a/jaxb-ri/xjc/src/test/resources/schemas/issue1788/binding.xjb
+++ b/jaxb-ri/xjc/src/test/resources/schemas/issue1788/binding.xjb
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Distribution License v. 1.0, which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: BSD-3-Clause
+
+-->
+
+<!-- See https://github.com/eclipse-ee4j/jaxb-ri/issues/1785 -->
+<jaxb:bindings xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" version="3.0">
+    <jaxb:bindings schemaLocation="*">
+        <jaxb:schemaBindings>
+            <jaxb:nameXmlTransform>
+                <jaxb:elementName prefix="My" suffix="Dto"/>
+                <jaxb:typeName prefix="My" suffix="Dto"/>
+            </jaxb:nameXmlTransform>
+        </jaxb:schemaBindings>
+    </jaxb:bindings>
+</jaxb:bindings>

--- a/jaxb-ri/xjc/src/test/resources/schemas/issue1788/schema.xsd
+++ b/jaxb-ri/xjc/src/test/resources/schemas/issue1788/schema.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Distribution License v. 1.0, which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: BSD-3-Clause
+
+-->
+
+<!-- See https://github.com/eclipse-ee4j/jaxb-ri/issues/1788 -->
+<xs:schema
+    targetNamespace="http://example.org/document"
+    xmlns:tns="http://example.org/document"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+>
+
+    <xs:complexType name="gh1788Type">
+        <xs:sequence>
+            <xs:element name="StringAttr" type="xs:string" minOccurs="0" nillable="true" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="gh1788" type="tns:gh1788Type"/>
+
+</xs:schema>


### PR DESCRIPTION
Fixes #1788 

This will ignore bindings files on `schemaLocation="*"` binding file instruction and will allow users to use it properly in code generation.