### PR TITLE
[#1803] better message in IllegalAnnotationsException

### DIFF
--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/IllegalAnnotationsException.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/IllegalAnnotationsException.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -35,19 +36,19 @@ public class IllegalAnnotationsException extends JAXBException {
     private static final long serialVersionUID = 1L;
 
     public IllegalAnnotationsException(List<IllegalAnnotationException> errors) {
-        super(errors.size()+" counts of IllegalAnnotationExceptions");
-        assert !errors.isEmpty() : "there must be at least one error";
+        super(buildMessage(errors));
         this.errors = Collections.unmodifiableList(new ArrayList<>(errors));
     }
 
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder(super.toString());
-        sb.append('\n');
-        
-        for( IllegalAnnotationException error : errors )
-            sb.append(error.toString()).append('\n');
+    private static String buildMessage(List<IllegalAnnotationException> errors) {
+        assert !errors.isEmpty() : "there must be at least one error";
 
+        StringBuilder sb = new StringBuilder(errors.size() * 200);
+        sb.append(errors.size()).append(" counts of IllegalAnnotationExceptions").append('\n');
+
+        for (IllegalAnnotationException error : errors) {
+            sb.append("- ").append(error.toString()).append('\n');
+        }
         return sb.toString();
     }
 

--- a/jaxb-ri/runtime/impl/src/test/java/org/glassfish/jaxb/runtime/v2/runtime/IllegalAnnotationsExceptionDTO.java
+++ b/jaxb-ri/runtime/impl/src/test/java/org/glassfish/jaxb/runtime/v2/runtime/IllegalAnnotationsExceptionDTO.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package org.glassfish.jaxb.runtime.v2.runtime;
+
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.util.Date;
+
+@XmlRootElement(name = "illegalAnnotationsExceptionDto")
+public class IllegalAnnotationsExceptionDTO {
+
+    @XmlAttribute(name = "field")
+    protected Date field;
+
+    public Date getField() {
+        return field;
+    }
+
+    public void setField(Date field) {
+        this.field = field;
+    }
+}

--- a/jaxb-ri/runtime/impl/src/test/java/org/glassfish/jaxb/runtime/v2/runtime/IllegalAnnotationsExceptionTest.java
+++ b/jaxb-ri/runtime/impl/src/test/java/org/glassfish/jaxb/runtime/v2/runtime/IllegalAnnotationsExceptionTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package org.glassfish.jaxb.runtime.v2.runtime;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class IllegalAnnotationsExceptionTest {
+    @Test
+    public void test() {
+        try {
+            JAXBContext.newInstance(IllegalAnnotationsExceptionDTO.class);
+            Assert.fail("no exception thrown");
+        } catch (IllegalAnnotationsException e) {
+            // actual message (x counts of IllegalAnnotationExceptions)
+            Assert.assertTrue(e.getMessage().contains("1 counts of IllegalAnnotationExceptions"));
+            // new detailed message containing location of exception if present (here it is)
+            Assert.assertTrue(e.getMessage().contains("this problem is related to the following location:"));
+        } catch (JAXBException e) {
+            Assert.fail("unexpected JAXBException");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1803

Add detail of errors in exception message in order to make this exception easier to proceed and analyse

Added test case (which could not be done on full message since we have message specific locale in some)