### PR TITLE
[#1440] handle adapter in mark-generated plugin

### DIFF
--- a/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JCodeModel.java
+++ b/jaxb-ri/codemodel/codemodel/src/main/java/com/sun/codemodel/JCodeModel.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -66,6 +67,9 @@ public final class JCodeModel {
     
     /** The packages that this JCodeWriter contains. */
     private final HashMap<String,JPackage> packages = new HashMap<>();
+
+    /** The adapters that this JCodeWriter contains. */
+    private final HashMap<String,JDefinedClass> adapters = new HashMap<>();
 
     /** Java module in {@code module-info.java} file. */
     private JModule module;
@@ -240,6 +244,22 @@ public final class JCodeModel {
         else
             return _package(fullyQualifiedName.substring(0,idx))
                 ._getClass( fullyQualifiedName.substring(idx+1) );
+    }
+
+    /**
+     * Adds an adapter to this code writer
+     * @param adapter the adapter to reference in this code writer
+     */
+    public void _adapter(JDefinedClass adapter) {
+        this.adapters.put(adapter.name(), adapter);
+    }
+
+    /**
+     * Returns an iterator that walks the adapters defined using this code writer.
+     * @return an iterator of the adapters used by this code writer
+     */
+    public Iterator<JDefinedClass> adapters() {
+        return adapters.values().iterator();
     }
 
     /**

--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/addon/at_generated/PluginImpl.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/addon/at_generated/PluginImpl.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -13,6 +14,7 @@ package com.sun.tools.xjc.addon.at_generated;
 import com.sun.codemodel.JAnnotatable;
 import com.sun.codemodel.JAnnotationUse;
 import com.sun.codemodel.JClass;
+import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JFieldVar;
 import com.sun.codemodel.JMethod;
 import com.sun.tools.xjc.BadCommandLineException;
@@ -26,6 +28,7 @@ import com.sun.tools.xjc.outline.PackageOutline;
 import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Iterator;
 
 import org.xml.sax.ErrorHandler;
 
@@ -72,25 +75,31 @@ public class PluginImpl extends Plugin {
         annotation = model.getCodeModel().ref(genAnnotation);
 
         for (ClassOutline co : model.getClasses()) {
-            augument(co);
+            augment(co);
         }
         for (EnumOutline eo : model.getEnums()) {
-            augument(eo);
+            augment(eo);
         }
         for (PackageOutline po : model.getAllPackageContexts()) {
-            augument(po);
+            augment(po);
+        }
+
+        // annotate XmlAdapter generated-classes
+        Iterator<JDefinedClass> it = model.getCodeModel().adapters();
+        while (it.hasNext()) {
+            annotate(it.next());
         }
         return true;
     }
 
-    private void augument(EnumOutline eo) {
+    private void augment(EnumOutline eo) {
         annotate(eo.clazz);
     }
 
     /**
      * Adds "@Generated" to the classes, methods, and fields.
      */
-    private void augument(ClassOutline co) {
+    private void augment(ClassOutline co) {
         annotate(co.implClass);
         for (JMethod m : co.implClass.methods())
             annotate(m);
@@ -98,7 +107,7 @@ public class PluginImpl extends Plugin {
             annotate(f);
     }
 
-    private void augument(PackageOutline po) {
+    private void augment(PackageOutline po) {
         annotate(po.objectFactory());
     }
 

--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/bindinfo/BIConversion.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/reader/xmlschema/bindinfo/BIConversion.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -168,6 +169,8 @@ public abstract class BIConversion extends AbstractDeclarationImpl {
                 try {
                     JPackage pkg = Ring.get(ClassSelector.class).getClassScope().getOwnerPackage();
                     adapter = pkg._class("Adapter"+id);
+                    // reference adapter in the CodeModel instance
+                    pkg.owner()._adapter(adapter);
                 } catch (JClassAlreadyExistsException e) {
                     // try another name in search for an unique name.
                     // this isn't too efficient, but we expect people to usually use

--- a/jaxb-ri/xjc/src/test/resources/schemas/issue1440/binding.xjb
+++ b/jaxb-ri/xjc/src/test/resources/schemas/issue1440/binding.xjb
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Distribution License v. 1.0, which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: BSD-3-Clause
+
+-->
+
+<!-- See https://github.com/eclipse-ee4j/jaxb-ri/issues/1440 -->
+<jaxb:bindings xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="3.0">
+    <jaxb:bindings schemaLocation="schema.xsd" node="/xs:schema">
+        <jaxb:globalBindings typesafeEnumBase="xs:string">
+            <jaxb:javaType name="long" xmlType="xs:unsignedLong" parseMethod="java.lang.Long.parseLong" printMethod="java.lang.Long.toString"/>
+        </jaxb:globalBindings>
+    </jaxb:bindings>
+</jaxb:bindings>

--- a/jaxb-ri/xjc/src/test/resources/schemas/issue1440/schema.xsd
+++ b/jaxb-ri/xjc/src/test/resources/schemas/issue1440/schema.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Distribution License v. 1.0, which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: BSD-3-Clause
+
+-->
+
+<!-- See https://github.com/eclipse-ee4j/jaxb-ri/issues/1440 -->
+<xs:schema
+    targetNamespace="http://example.org/document"
+    xmlns:tns="http://example.org/document"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+>
+
+    <xs:complexType name="gh1440Type">
+        <xs:sequence>
+            <xs:element name="Value" type="xs:unsignedLong"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="gh1440" type="tns:gh1440Type"/>
+
+</xs:schema>


### PR DESCRIPTION
Fixes #1440 

Generated XmlAdapter classes are now referenced in CodeModel and can be used in plugin like the `mark-generated` one

Added test case too