### PR TITLE
Set disableSecurityProcessing to false by default instead of true to prevent XXE attacks

### DIFF
--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/ContextFactory.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/ContextFactory.java
@@ -195,6 +195,7 @@ public class ContextFactory {
         builder.setAllNillable(allNillable);
         builder.setRetainPropertyInfo(retainPropertyInfo);
         builder.setImprovedXsiTypeHandling(improvedXsiTypeHandling);
+        builder.setDisableSecurityProcessing(false);
         return builder.build();
     }
 

--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/JAXBContextImpl.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/JAXBContextImpl.java
@@ -1001,7 +1001,7 @@ public final class JAXBContextImpl extends JAXBRIContext {
         private boolean xmlAccessorFactorySupport = false;
         private boolean allNillable;
         private boolean improvedXsiTypeHandling = true;
-        private boolean disableSecurityProcessing = true;
+        private boolean disableSecurityProcessing = false;
         private Boolean backupWithParentNamespace = null; // null for System property to be used
         private int maxErrorsCount;
 


### PR DESCRIPTION
jaxb-ri should use a secure config by default to prevent to be vulnerable to XXE attacks.

I guess this is not the case until now for compability reasons?

A release note should probably be added.