### PR TITLE
Adjust code to provide basic Android support

### DIFF
--- a/jaxb-ri/core/src/main/java/org/glassfish/jaxb/core/StackHelper.java
+++ b/jaxb-ri/core/src/main/java/org/glassfish/jaxb/core/StackHelper.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
  * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -18,7 +19,7 @@ import java.lang.StackWalker.StackFrame;
  * @author Philippe Marschall
  */
 final class StackHelper {
-    private StackHelper() {}   // no instanciation
+    private StackHelper() {}   // no instantiation
 
     /**
      * Returns the name of the calling class of the second method in the call chain of this method.
@@ -28,17 +29,14 @@ final class StackHelper {
      *                           prevents stack introspection
      */
     static String getCallerClassName() {
-        try
-        {
+        try {
             return StackWalker.getInstance()
                     .walk(frames ->
                             frames.map(StackFrame::getClassName)
                                     .skip(2L)
                                     .findFirst()
                                     .get());
-        }
-        catch (NoClassDefFoundError ignored)
-        {
+        } catch (NoClassDefFoundError ignored) {
             StackTraceElement[] trace = new Exception().getStackTrace();
             return trace[1].getClassName();
         }

--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/MUtils.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/MUtils.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
  * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -42,7 +43,6 @@ final class MUtils {
      * @throws JAXBException if any of a classes package is not open to our module.
      */
     static void open(Class[] classes) throws JAXBException {
-
         if (!MODULES_SUPPORTED) {
             //we are in an environment like Android which doesn't support Java 9 modules
             return;

--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/model/impl/GetterSetterPropertySeed.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/model/impl/GetterSetterPropertySeed.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -77,24 +78,19 @@ class GetterSetterPropertySeed<TypeT,ClassDeclT,FieldT,MethodT> implements
 
 
     private static String camelize(String s) {
-        try
-        {
+        try {
             return Introspector.decapitalize(s);
-        }
-        catch (NoClassDefFoundError ignored)
-        {
-            if (s == null)
-            {
+        } catch (NoClassDefFoundError ignored) {
+            if (s == null) {
                 return null;
             }
 
-            if (s.isEmpty())
+            if (s.isEmpty()) {
                 return s;
+            }
 
-            if (Character.isUpperCase(s.charAt(0)))
-            {
-                if (s.length() > 1 && !Character.isUpperCase(s.charAt(1)))
-                {
+            if (Character.isUpperCase(s.charAt(0))) {
+                if (s.length() > 1 && !Character.isUpperCase(s.charAt(1))) {
                     char c = Character.toLowerCase(s.charAt(0));
                     s = c + s.substring(1);
                 }

--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/model/impl/RuntimeBuiltinLeafInfoImpl.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/model/impl/RuntimeBuiltinLeafInfoImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
  * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -375,11 +376,11 @@ public abstract class RuntimeBuiltinLeafInfoImpl<T> extends BuiltinLeafInfoImpl<
             secondaryList.add(
                     new PcdataImpl<Image>(Image.class, createXS("base64Binary")) {
                         @Override
-                        public Image parse(CharSequence text) throws SAXException  {
+                        public Image parse(CharSequence text) throws SAXException {
                             try {
                                 InputStream is;
-                                if(text instanceof Base64Data)
-                                    is = ((Base64Data)text).getInputStream();
+                                if (text instanceof Base64Data)
+                                    is = ((Base64Data) text).getInputStream();
                                 else
                                     is = new ByteArrayInputStream(decodeBase64(text)); // TODO: buffering is inefficient
 
@@ -400,10 +401,11 @@ public abstract class RuntimeBuiltinLeafInfoImpl<T> extends BuiltinLeafInfoImpl<
 
                         private BufferedImage convertToBufferedImage(Image image) throws IOException {
                             if (image instanceof BufferedImage) {
-                                return (BufferedImage)image;
+                                return (BufferedImage) image;
 
                             } else {
-                                MediaTracker tracker = new MediaTracker(new Component(){}); // not sure if this is the right thing to do.
+                                MediaTracker tracker = new MediaTracker(new Component() {
+                                }); // not sure if this is the right thing to do.
                                 tracker.addImage(image, 0);
                                 try {
                                     tracker.waitForAll();
@@ -427,7 +429,7 @@ public abstract class RuntimeBuiltinLeafInfoImpl<T> extends BuiltinLeafInfoImpl<
                             XMLSerializer xs = XMLSerializer.getInstance();
 
                             String mimeType = xs.getXMIMEContentType();
-                            if(mimeType==null || mimeType.startsWith("image/*"))
+                            if (mimeType == null || mimeType.startsWith("image/*"))
                                 // because PNG is lossless, it's a good default
                                 //
                                 // mime type can be a range, in which case we can't just pass that
@@ -437,7 +439,7 @@ public abstract class RuntimeBuiltinLeafInfoImpl<T> extends BuiltinLeafInfoImpl<
 
                             try {
                                 Iterator<ImageWriter> itr = ImageIO.getImageWritersByMIMEType(mimeType);
-                                if(itr.hasNext()) {
+                                if (itr.hasNext()) {
                                     ImageWriter w = itr.next();
                                     ImageOutputStream os = ImageIO.createImageOutputStream(imageData);
                                     w.setOutput(os);
@@ -449,9 +451,9 @@ public abstract class RuntimeBuiltinLeafInfoImpl<T> extends BuiltinLeafInfoImpl<
                                     xs.handleEvent(new ValidationEventImpl(
                                             ValidationEvent.ERROR,
                                             Messages.NO_IMAGE_WRITER.format(mimeType),
-                                            xs.getCurrentLocation(null) ));
+                                            xs.getCurrentLocation(null)));
                                     // TODO: proper error reporting
-                                    throw new RuntimeException("no encoder for MIME type "+mimeType);
+                                    throw new RuntimeException("no encoder for MIME type " + mimeType);
                                 }
                             } catch (IOException e) {
                                 xs.handleError(e);
@@ -459,12 +461,11 @@ public abstract class RuntimeBuiltinLeafInfoImpl<T> extends BuiltinLeafInfoImpl<
                                 throw new RuntimeException(e);
                             }
                             Base64Data bd = new Base64Data();
-                            imageData.set(bd,mimeType);
+                            imageData.set(bd, mimeType);
                             return bd;
                         }
                     });
-        }
-        catch (ClassNotFoundException ignored) {
+        } catch (ClassNotFoundException ignored) {
             // Runtime which doesn't have awt (like Android)
         }
         secondaryList.add(

--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/reflect/Accessor.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/reflect/Accessor.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
  * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -152,10 +153,10 @@ public abstract class Accessor<BeanT, ValueT> implements Receiver {
     );
 
     public boolean isValueTypeAbstractable() {
-        try
-        {
-            if (getValueType() == java.awt.Image.class)
+        try {
+            if (getValueType() == java.awt.Image.class) {
                 return false;
+            }
         } catch (NoClassDefFoundError ignored) {}
 
         return !nonAbstractableClasses.contains(getValueType());
@@ -167,10 +168,10 @@ public abstract class Accessor<BeanT, ValueT> implements Receiver {
      * @return true if it is NOT builtin class
      */
     public boolean isAbstractable(Class clazz) {
-        try
-        {
-            if (getValueType() == clazz)
+        try {
+            if (getValueType() == clazz) {
                 return false;
+            }
         } catch (NoClassDefFoundError ignored) {}
 
         return !nonAbstractableClasses.contains(clazz);


### PR DESCRIPTION
The following code adds JAXB marshalling and unmarshalling support for Android Java runtime, as ART is implemented differently than a standard Openjdk implementation.

[StackWalker](https://developer.android.com/reference/java/lang/StackWalker) is present in Android API since API Level 34 (Android 14) which approximately 50% of devices currently supports, which is why I have decided to provide an alternative implementation for older API levels (based from the previous Jakarta code before bumping to Jdk11)

Android does not provide any implementation for java.awt.*, which is why I check during runtime if this classes are present,
Android also does not provide a StaX implementation, which is why I added an extra StaX dependency found online, I belive if there is any interest to remove StaX dependency for Android it whould be done on another PR.

Android also, does not support Java 9+ modules, according to the previous code of MUtils the function was empty before switching to Jdk9, which is where I replicate such behaviour.

All maven tests passes.

Relevant code that was tested under Android:
```
    public static <T> void marshalRes(T req, Writer in) throws JAXBException, IOException {
        JAXBContext ctx = JAXBContext.newInstance(req.getClass());
        Marshaller m = ctx.createMarshaller();
        StringWriter w = new StringWriter();
        m.marshal(req, w);
        String p = w.toString();
        in.write(p);
    }
```

without this edits, JAXBContext.newInstance would crash, while on Openjdk it would work as intended.

Extra environment information for replicating marshaller/unmarshaller tests:
- Gradle: 9.1.0 /w AGP 8.13.0
- Min SDK: 24
- Max SDK: 34
- Compile SDK: 36
- Desugaring enabled with source and target version set to Java 11
- Successfully run on Android 7.1

Dependencies added:
- org.glassfish.jaxb:jaxb-core with this patches
- org.glassfish.jaxb:jaxb-runtime with this patches
- jakarta.xml.bind:jakarta.xml.bind-api:4.0.4
- javax.xml.stream:stax-api:1.0-2
