### PR TITLE
unmarshaller performance: use bulk operations instead of charAt() where possible

### DIFF
--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/unmarshaller/ValidatingUnmarshaller.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/unmarshaller/ValidatingUnmarshaller.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at


### PR DESCRIPTION
assuming the minimum Java version 11 is correct (as mentioned in the 4.0.3 release notes), this should be a viable performance improvement for the very common case of processing a String event from the SAX parser