### PR TITLE
fix wrong length calculation in IntData

### DIFF
--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/unmarshaller/IntData.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/unmarshaller/IntData.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -23,7 +24,7 @@ import java.io.IOException;
 public class IntData extends Pcdata {
     /**
      * The int value that this {@link Pcdata} represents.
-     *
+     * <p>
      * Modifiable.
      */
     private int data;

--- a/jaxb-ri/runtime/impl/src/test/java/org/glassfish/jaxb/runtime/v2/runtime/unmarshaller/IntDataTest.java
+++ b/jaxb-ri/runtime/impl/src/test/java/org/glassfish/jaxb/runtime/v2/runtime/unmarshaller/IntDataTest.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
 package org.glassfish.jaxb.runtime.v2.runtime.unmarshaller;
 
 import org.junit.Test;


### PR DESCRIPTION
`IntData`'s string length calculation is wrong for certain values. This became apparent when executing code like this:
```java
IntData intData = new IntData();
intData.reset(54321);

char[] buf = new char[intData.length()];
for( int i=0;i<intData.length(); i++ )
            buf[i] = intData.charAt(i);
```
Because `intData.length()` is erroneously calculated as 6 instead of 5, this loop will fail with `IndexOutOfBoundsException` in the last iteration.