### PR TITLE
[#1440] handle adapters in mark-generated plugin (w/ refacto)

### DIFF
--- a/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/addon/at_generated/PluginImpl.java
+++ b/jaxb-ri/xjc/src/main/java/com/sun/tools/xjc/addon/at_generated/PluginImpl.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2021 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,22 +11,24 @@
 
 package com.sun.tools.xjc.addon.at_generated;
 
+import com.sun.codemodel.ClassType;
 import com.sun.codemodel.JAnnotatable;
 import com.sun.codemodel.JAnnotationUse;
 import com.sun.codemodel.JClass;
+import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JFieldVar;
 import com.sun.codemodel.JMethod;
+import com.sun.codemodel.JModule;
 import com.sun.tools.xjc.BadCommandLineException;
 import com.sun.tools.xjc.Driver;
 import com.sun.tools.xjc.Options;
 import com.sun.tools.xjc.Plugin;
-import com.sun.tools.xjc.outline.ClassOutline;
-import com.sun.tools.xjc.outline.EnumOutline;
 import com.sun.tools.xjc.outline.Outline;
 import com.sun.tools.xjc.outline.PackageOutline;
 import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Iterator;
 
 import org.xml.sax.ErrorHandler;
 
@@ -71,35 +74,43 @@ public class PluginImpl extends Plugin {
         // we want this to work without requiring Jakarta annotations jar.
         annotation = model.getCodeModel().ref(genAnnotation);
 
-        for (ClassOutline co : model.getClasses()) {
-            augument(co);
-        }
-        for (EnumOutline eo : model.getEnums()) {
-            augument(eo);
-        }
         for (PackageOutline po : model.getAllPackageContexts()) {
-            augument(po);
+            augment(po);
         }
-        return true;
-    }
 
-    private void augument(EnumOutline eo) {
-        annotate(eo.clazz);
+        JModule module = model.getCodeModel()._getModuleInfo();
+        augment(module);
+
+        return true;
     }
 
     /**
      * Adds "@Generated" to the classes, methods, and fields.
      */
-    private void augument(ClassOutline co) {
-        annotate(co.implClass);
-        for (JMethod m : co.implClass.methods())
-            annotate(m);
-        for (JFieldVar f : co.implClass.fields().values())
-            annotate(f);
+    private void augment(JDefinedClass co) {
+        annotate(co);
+        if (co.getClassType() != ClassType.ENUM) {
+            for (JMethod m : co.methods()) {
+                annotate(m);
+            }
+            for (JFieldVar f : co.fields().values()) {
+                annotate(f);
+            }
+        }
     }
 
-    private void augument(PackageOutline po) {
-        annotate(po.objectFactory());
+    private void augment(JModule module) {
+        if (module != null) {
+            annotate(module);
+        }
+    }
+
+    private void augment(PackageOutline po) {
+        annotate(po._package());
+        for (Iterator<JDefinedClass> it = po._package().classes(); it.hasNext(); ) {
+            JDefinedClass clazz = it.next();
+            augment(clazz);
+        }
     }
 
     private void annotate(JAnnotatable m) {

--- a/jaxb-ri/xjc/src/test/java/com/sun/tools/xjc/CodeGenTest.java
+++ b/jaxb-ri/xjc/src/test/java/com/sun/tools/xjc/CodeGenTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021, 2024 Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
+ * Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -11,11 +11,13 @@
 
 package com.sun.tools.xjc;
 
+import com.sun.codemodel.JAnnotationUse;
 import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JDeclaration;
 import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JFormatter;
 import com.sun.codemodel.JMethod;
+import com.sun.codemodel.JPackage;
 import com.sun.codemodel.JType;
 import com.sun.codemodel.writer.SingleStreamCodeWriter;
 import com.sun.tools.xjc.api.ErrorListener;
@@ -288,6 +290,63 @@ public class CodeGenTest extends TestCase {
                 " *   </restriction>" + System.lineSeparator() +
                 " * </simpleType>" + System.lineSeparator() +
                 " * }</pre>"));
+    }
+
+    /**
+     * Test issues #1440 for mark-generated on adapters
+     *
+     * @throws FileNotFoundException When the test schema or binding file cannot be read.
+     * @throws URISyntaxException When the test {@link InputSource} cannot be parsed.
+     *
+     * @see <a href="https://github.com/eclipse-ee4j/jaxb-ri/issues/1440">Issue #1440</a>
+     */
+    public void testIssue1440() throws FileNotFoundException, URISyntaxException, BadCommandLineException {
+        String schemaFileName = "/schemas/issue1440/schema.xsd";
+        String bindingFileName = "/schemas/issue1440/binding.xjb";
+        String packageName = "org.example.issue1440";
+        String someClassName = packageName + ".Gh1440Type";
+
+        ErrorListener errorListener = new ConsoleErrorReporter();
+
+        // Parse the XML schema.
+        SchemaCompiler sc = XJC.createSchemaCompiler();
+        sc.setErrorListener(errorListener);
+        sc.forcePackageName(packageName);
+        sc.parseSchema(getInputSource(schemaFileName));
+        sc.getOptions().addGrammar(getInputSource(schemaFileName));
+        sc.getOptions().addBindFile(getInputSource(bindingFileName));
+        sc.getOptions().parseArguments(new String[] { "-mark-generated" });
+
+        // Generate the defined class.
+        S2JJAXBModel model = sc.bind();
+        Plugin[] extensions = new Plugin[]{ new com.sun.tools.xjc.addon.at_generated.PluginImpl() };
+        JCodeModel cm = model.generateCode(extensions, errorListener);
+        JDefinedClass dc = cm._getClass(someClassName);
+        assertNotNull(someClassName, dc);
+
+        // Assert Class includes narrow type
+        Iterator<JMethod> conIter = dc.constructors();
+        while (conIter.hasNext()) {
+            JMethod con = conIter.next();
+            assertTrue(toString(con).contains("java.lang.Class<java.lang.String>"));
+        }
+
+        Iterator<JPackage> packagesIt = cm.packages();
+        assertTrue("Should have one package", packagesIt.hasNext());
+        JPackage aPackage = packagesIt.next();
+        assertNotNull("Package should not be null", aPackage);
+        Iterator<JDefinedClass> classesIt = aPackage.classes();
+        assertTrue("Should have one class", classesIt.hasNext());
+        while (classesIt.hasNext()) {
+            JDefinedClass clazz = classesIt.next();
+            assertNotNull("Class should not be null", clazz);
+            assertFalse("Should have at least one annotation", clazz.annotations().isEmpty());
+            // find Generated annotation
+            JAnnotationUse annotation = clazz.annotations().stream().filter(
+                    a -> "jakarta.annotation.Generated".equals(a.getAnnotationClass().fullName()))
+                    .findFirst().orElse(null);
+            assertNotNull("Annotation @Generated should not be null", annotation);
+        }
     }
 
     private void assertNonEmptyJavadocBlocks(String cmString) throws IOException {

--- a/jaxb-ri/xjc/src/test/resources/schemas/issue1440/binding.xjb
+++ b/jaxb-ri/xjc/src/test/resources/schemas/issue1440/binding.xjb
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Distribution License v. 1.0, which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: BSD-3-Clause
+
+-->
+
+<!-- See https://github.com/eclipse-ee4j/jaxb-ri/issues/1440 -->
+<jaxb:bindings xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" xmlns:xs="http://www.w3.org/2001/XMLSchema" version="3.0">
+    <jaxb:bindings schemaLocation="schema.xsd" node="/xs:schema">
+        <jaxb:globalBindings typesafeEnumBase="xs:string">
+            <jaxb:javaType name="long" xmlType="xs:unsignedLong" parseMethod="java.lang.Long.parseLong" printMethod="java.lang.Long.toString"/>
+        </jaxb:globalBindings>
+    </jaxb:bindings>
+</jaxb:bindings>

--- a/jaxb-ri/xjc/src/test/resources/schemas/issue1440/schema.xsd
+++ b/jaxb-ri/xjc/src/test/resources/schemas/issue1440/schema.xsd
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Distribution License v. 1.0, which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: BSD-3-Clause
+
+-->
+
+<!-- See https://github.com/eclipse-ee4j/jaxb-ri/issues/1440 -->
+<xs:schema
+        targetNamespace="http://example.org/document"
+        xmlns:tns="http://example.org/document"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+>
+
+    <xs:complexType name="gh1440Type">
+        <xs:sequence>
+            <xs:element name="Value" type="xs:unsignedLong"/>
+            <xs:element name="EnumValue" type="tns:gh1440Enum" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="gh1440Enum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="FOO" />
+            <xs:enumeration value="BAR" />
+            <xs:enumeration value="FOO_BAR" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:element name="gh1440" type="tns:gh1440Type"/>
+
+</xs:schema>


### PR DESCRIPTION
Fixes #1440 

Also add `JModule` as handled by `mark-generated` plugin

New implementation that doesn't add extra properties on Outline / Model
Added test case too