### PR TITLE
Revert parent 2.0.0 - "Bump the dependencies group across 4 directories with 1 update (#1905)"

### DIFF
--- a/jaxb-ri/boms/bom/pom.xml
+++ b/jaxb-ri/boms/bom/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>2.0.0</version>
+        <version>1.0.9</version>
         <relativePath/>
     </parent>
 

--- a/jaxb-ri/codemodel/pom.xml
+++ b/jaxb-ri/codemodel/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>2.0.0</version>
+        <version>1.0.9</version>
         <relativePath/>
     </parent>
 

--- a/jaxb-ri/external/pom.xml
+++ b/jaxb-ri/external/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>2.0.0</version>
+        <version>1.0.9</version>
         <relativePath/>
     </parent>
 

--- a/jaxb-ri/xsom/pom.xml
+++ b/jaxb-ri/xsom/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>2.0.0</version>
+        <version>1.0.9</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
central publishing plugin is unable to handle projects with components under more than one groupId

This reverts commit 44c9f6254e1326468eaf9d2b304776c58c43fb0b.