### PR TITLE
[#1935] optimize getXmlReader() by sharing SAXParserFactory in JAXBContext

### DIFF
--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/JAXBContextImpl.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/JAXBContextImpl.java
@@ -57,6 +57,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.FactoryConfigurationError;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.Result;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
@@ -216,6 +217,12 @@ public final class JAXBContextImpl extends JAXBRIContext {
      * @since 2.3.3
      */
     public final int maxErrorsCount;
+
+    /**
+     * The parserFactory for this JAXBContext
+     * @since 4.0.8
+     */
+    private volatile SAXParserFactory parserFactory;
 
     /**
      * Returns declared XmlNs annotations (from package-level annotation XmlSchema
@@ -987,6 +994,24 @@ public final class JAXBContextImpl extends JAXBRIContext {
             return lhs.getNamespaceURI().compareTo(rhs.getNamespaceURI());
         }
     };
+
+    public SAXParserFactory getSAXParserFactory() {
+        SAXParserFactory factory = parserFactory;
+        if (factory == null) {
+            synchronized (this) {
+                factory = parserFactory;
+                if (factory == null) {
+                    factory = XmlFactory.createParserFactory(disableSecurityProcessing);
+                    // there is no point in asking a validation because
+                    // there is no guarantee that the document will come with
+                    // a proper schemaLocation.
+                    factory.setValidating(false);
+                    parserFactory = factory;
+                }
+            }
+        }
+        return factory;
+    }
 
     public static class JAXBContextBuilder {
 

--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/unmarshaller/UnmarshallerImpl.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/unmarshaller/UnmarshallerImpl.java
@@ -99,32 +99,27 @@ public final class UnmarshallerImpl extends AbstractUnmarshallerImpl implements 
 
     /**
      * Obtains a configured XMLReader.
-     * 
+     *
      * This method is used when the client-specified
      * {@link SAXSource} object doesn't have XMLReader.
-     * 
+     *
      * {@link Unmarshaller} is not re-entrant, so we will
      * only use one instance of XMLReader.
-     * 
+     *
      * Overriden in order to fix potential security issue.
      */
      @Override
     protected XMLReader getXMLReader() throws JAXBException {
          if (reader == null) {
              try {
-                 SAXParserFactory parserFactory = XmlFactory.createParserFactory(context.disableSecurityProcessing);
-                 // there is no point in asking a validation because 
-                 // there is no guarantee that the document will come with
-                 // a proper schemaLocation.
-                 parserFactory.setValidating(false);
-                 reader = parserFactory.newSAXParser().getXMLReader();
+                 reader = context.getSAXParserFactory().newSAXParser().getXMLReader();
              } catch (ParserConfigurationException | SAXException e) {
                  throw new JAXBException(e);
              }
          }
          return reader;
      }
-    
+
     private SAXConnector getUnmarshallerHandler( boolean intern, JaxBeanInfo expectedType ) {
         XmlVisitor h = createUnmarshallerHandler(null, false, expectedType);
         if (intern) {


### PR DESCRIPTION
Fixes #1935 

Optimize the `getXmlReader()` method in `UnmarshallerImpl` by using a shared instance of `SAXParserFactory` hold by `JAXBContextImpl`