### PR TITLE
fix broken double-checked locking in `DatatypeConverterImpl`

### DIFF
--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/DatatypeConverterImpl.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/DatatypeConverterImpl.java
@@ -719,21 +719,13 @@ public final class DatatypeConverterImpl implements DatatypeConverterInterface {
 
     public static DatatypeFactory getDatatypeFactory() {
         ClassLoader tccl = Thread.currentThread().getContextClassLoader();
-        DatatypeFactory df = DF_CACHE.get(tccl);
-        if (df == null) {
-            synchronized (DatatypeConverterImpl.class) {
-                df = DF_CACHE.get(tccl);
-                if (df == null) { // to prevent multiple initialization
-                    try {
-                        df = DatatypeFactory.newInstance();
-                    } catch (DatatypeConfigurationException e) {
-                        throw new Error(Messages.FAILED_TO_INITIALE_DATATYPE_FACTORY.format(),e);
-                    }
-                    DF_CACHE.put(tccl, df);
-                }
+        return DF_CACHE.computeIfAbsent(tccl, k -> {
+            try {
+                return DatatypeFactory.newInstance();
+            } catch (DatatypeConfigurationException e) {
+                throw new Error(Messages.FAILED_TO_INITIALE_DATATYPE_FACTORY.format(), e);
             }
-        }
-        return df;
+        });
     }
 
     private static final class CalendarFormatter {


### PR DESCRIPTION
The `DatatypeConverterImpl.getDatatypeFactory()` method used double-checked locking with a `synchronizedMap` but synchronized on `DatatypeConverterImpl.class`. There are 2 issues with this:
* `DF_CACHE.get(tccl)` outside the `synchronized` block and inside used different locks (map's internal lock vs. class lock), so the double-checked locking pattern was broken
* It was redundant to use both the `synchronized` block and a `synchronizedMap`