### PR TITLE
Bump org.apache.maven.plugins:maven-enforcer-plugin

### DIFF
--- a/jaxb-ri/boms/bom/pom.xml
+++ b/jaxb-ri/boms/bom/pom.xml
@@ -267,7 +267,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.6.2</version>
+                    <version>3.6.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/jaxb-ri/pom.xml
+++ b/jaxb-ri/pom.xml
@@ -337,7 +337,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.6.2</version>
+                    <version>3.6.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Bumps the maven-plugins group in /jaxb-ri with 1 update: [org.apache.maven.plugins:maven-enforcer-plugin](https://github.com/apache/maven-enforcer).

Updates `org.apache.maven.plugins:maven-enforcer-plugin` from 3.6.2 to 3.6.3
- [Release notes](https://github.com/apache/maven-enforcer/releases)
- [Commits](https://github.com/apache/maven-enforcer/compare/enforcer-3.6.2...enforcer-3.6.3)

---
updated-dependencies:
- dependency-name: org.apache.maven.plugins:maven-enforcer-plugin dependency-version: 3.6.3 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: maven-plugins ...


(cherry picked from commit de55b927288c2508ea8ab2210f20686ecaa01364)