### PR TITLE
Bump org.eclipse.ee4j:project in /jaxb-ri in the dependencies group

### DIFF
--- a/jaxb-ri/boms/bom/pom.xml
+++ b/jaxb-ri/boms/bom/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.4</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
Bumps the dependencies group in /jaxb-ri with 1 update: [org.eclipse.ee4j:project](https://github.com/eclipse-ee4j/ee4j).

Updates `org.eclipse.ee4j:project` from 2.0.2 to 2.0.4
- [Release notes](https://github.com/eclipse-ee4j/ee4j/releases)
- [Commits](https://github.com/eclipse-ee4j/ee4j/compare/2.0.2...2.0.4)

---
updated-dependencies:
- dependency-name: org.eclipse.ee4j:project dependency-version: 2.0.4 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: dependencies ...


(cherry picked from commit 7e4138c7bb154b1ceafe026cf496125698d3f997)