### PR TITLE
add configurable policy for XML-illegal characters (JAXB-614)

### DIFF
--- a/jaxb-ri/core/src/main/java/org/glassfish/jaxb/core/marshaller/InvalidXmlCharacterEscapeHandler.java
+++ b/jaxb-ri/core/src/main/java/org/glassfish/jaxb/core/marshaller/InvalidXmlCharacterEscapeHandler.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package org.glassfish.jaxb.core.marshaller;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * A {@link CharacterEscapeHandler} decorator that removes or replaces
+ * characters illegal in serialized XML 1.0 before delegating to another
+ * handler.
+ *
+ * <p>
+ * The JAXB RI historically marshalled C0 control characters (and a couple of
+ * other code points forbidden by the XML 1.0 {@code Char} production) verbatim,
+ * producing output that cannot be parsed back in &mdash; see
+ * <a href="https://github.com/eclipse-ee4j/jaxb-ri/issues/614">JAXB-614</a>.
+ * Because XML 1.0 does not permit these characters even as numeric character
+ * references, the only way to keep the output well-formed is to drop them
+ * ({@link InvalidXmlCharacterPolicy#STRIP}) or substitute a legal character
+ * ({@link InvalidXmlCharacterPolicy#REPLACE}).
+ *
+ * <p>
+ * This handler only filters the offending characters; it leaves all normal XML
+ * escaping (of {@code &}, {@code <}, {@code >}, quotes, CR/LF, etc.) to the
+ * wrapped handler so behaviour is otherwise unchanged.
+ */
+public class InvalidXmlCharacterEscapeHandler implements CharacterEscapeHandler {
+
+    private final CharacterEscapeHandler core;
+    private final InvalidXmlCharacterPolicy policy;
+
+    /**
+     * @param core   the handler that performs the normal XML escaping; must not
+     *               be {@code null}
+     * @param policy how to treat illegal XML 1.0 characters; must not be
+     *               {@code null} and is expected to be
+     *               {@link InvalidXmlCharacterPolicy#STRIP} or
+     *               {@link InvalidXmlCharacterPolicy#REPLACE}
+     */
+    public InvalidXmlCharacterEscapeHandler(CharacterEscapeHandler core, InvalidXmlCharacterPolicy policy) {
+        this.core = core;
+        this.policy = policy;
+    }
+
+    /**
+     * Wraps {@code core} only when {@code policy} actually changes behaviour.
+     * For {@link InvalidXmlCharacterPolicy#WRITE} (or a {@code null} policy) the
+     * original handler is returned unchanged, so the common path pays nothing.
+     */
+    public static CharacterEscapeHandler wrap(CharacterEscapeHandler core, InvalidXmlCharacterPolicy policy) {
+        if (policy == null || policy == InvalidXmlCharacterPolicy.WRITE) {
+            return core;
+        }
+        return new InvalidXmlCharacterEscapeHandler(core, policy);
+    }
+
+    @Override
+    public void escape(char[] ch, int start, int length, boolean isAttVal, Writer out) throws IOException {
+        int limit = start + length;
+
+        // Fast path: scan for the first illegal character. The overwhelming
+        // majority of payloads contain none, in which case we delegate the
+        // original array range directly and allocate nothing.
+        int firstBad = start;
+        while (firstBad < limit && !InvalidXmlCharacterPolicy.isInvalid(ch[firstBad])) {
+            firstBad++;
+        }
+        if (firstBad == limit) {
+            core.escape(ch, start, length, isAttVal, out);
+            return;
+        }
+
+        // Slow path: build a filtered copy, preserving everything legal.
+        char[] filtered = new char[length];
+        int len = 0;
+        for (int i = start; i < limit; i++) {
+            char c = ch[i];
+            if (InvalidXmlCharacterPolicy.isInvalid(c)) {
+                if (policy == InvalidXmlCharacterPolicy.REPLACE) {
+                    filtered[len++] = InvalidXmlCharacterPolicy.REPLACEMENT_CHAR;
+                }
+                // STRIP: drop the character entirely.
+            } else {
+                filtered[len++] = c;
+            }
+        }
+        core.escape(filtered, 0, len, isAttVal, out);
+    }
+}

--- a/jaxb-ri/core/src/main/java/org/glassfish/jaxb/core/marshaller/InvalidXmlCharacterPolicy.java
+++ b/jaxb-ri/core/src/main/java/org/glassfish/jaxb/core/marshaller/InvalidXmlCharacterPolicy.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package org.glassfish.jaxb.core.marshaller;
+
+/**
+ * How the marshaller should treat characters that are legal in a Java
+ * {@link String} but illegal in serialized XML 1.0.
+ *
+ * <p>
+ * The XML 1.0 {@code Char} production (see
+ * <a href="https://www.w3.org/TR/xml/#charsets">XML 1.0 &sect;2.2</a>) forbids
+ * most C0 control characters (every code point below {@code 0x20} other than
+ * {@code \t}, {@code \n} and {@code \r}), as well as {@code U+FFFE} and
+ * {@code U+FFFF}. Crucially, XML 1.0 does not allow these characters even as
+ * numeric character references, so there is no lossless escaping that keeps the
+ * output parseable. Historically the JAXB RI marshalled such characters
+ * verbatim, producing XML that fails to parse on the way back in (see
+ * <a href="https://github.com/eclipse-ee4j/jaxb-ri/issues/614">JAXB-614</a>).
+ *
+ * <p>
+ * The behaviour is selected through the
+ * {@value #PROPERTY_NAME} marshaller property or the system property of the
+ * same name. The default is {@link #WRITE}, which preserves the historical
+ * (non-compliant) behaviour for backward compatibility.
+ */
+public enum InvalidXmlCharacterPolicy {
+
+    /**
+     * Write the character to the output unchanged. This reproduces the
+     * historical behaviour and can yield XML that is not well-formed.
+     */
+    WRITE,
+
+    /**
+     * Silently drop the offending character from the output. The resulting XML
+     * is well-formed but the character is lost.
+     */
+    STRIP,
+
+    /**
+     * Replace the offending character with the Unicode replacement character
+     * ({@code U+FFFD}), which is itself a legal XML 1.0 character. The resulting
+     * XML is well-formed and round-trips.
+     */
+    REPLACE;
+
+    /**
+     * Name of the marshaller property and system property that selects the
+     * policy. Accepted values are the (case-insensitive) enum constant names.
+     */
+    public static final String PROPERTY_NAME = "org.glassfish.jaxb.invalidXmlCharacterPolicy";
+
+    /**
+     * The character substituted for an illegal one under {@link #REPLACE}.
+     */
+    public static final char REPLACEMENT_CHAR = '\uFFFD';
+
+    /**
+     * Returns whether the given character is illegal in serialized XML 1.0
+     * character data.
+     */
+    public static boolean isInvalid(char c) {
+        if (c < 0x20) {
+            return c != '\t' && c != '\n' && c != '\r';
+        }
+        return c == '\uFFFE' || c == '\uFFFF';
+    }
+
+    /**
+     * Parses a policy from its name, case-insensitively. Returns {@link #WRITE}
+     * for a {@code null}, blank, or unrecognized value so that a stray
+     * configuration value can never make marshalling fail.
+     */
+    public static InvalidXmlCharacterPolicy parse(String value) {
+        if (value == null) {
+            return WRITE;
+        }
+        for (InvalidXmlCharacterPolicy policy : values()) {
+            if (policy.name().equalsIgnoreCase(value.trim())) {
+                return policy;
+            }
+        }
+        return WRITE;
+    }
+
+    /**
+     * Resolves the default policy from the {@value #PROPERTY_NAME} system
+     * property, falling back to {@link #WRITE} when unset.
+     */
+    public static InvalidXmlCharacterPolicy resolveDefault() {
+        return parse(System.getProperty(PROPERTY_NAME));
+    }
+}

--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/MarshallerImpl.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/MarshallerImpl.java
@@ -48,6 +48,8 @@ import jakarta.xml.bind.helpers.AbstractMarshallerImpl;
 import org.glassfish.jaxb.core.marshaller.CharacterEscapeHandler;
 import org.glassfish.jaxb.core.marshaller.DataWriter;
 import org.glassfish.jaxb.core.marshaller.DumbEscapeHandler;
+import org.glassfish.jaxb.core.marshaller.InvalidXmlCharacterEscapeHandler;
+import org.glassfish.jaxb.core.marshaller.InvalidXmlCharacterPolicy;
 import org.glassfish.jaxb.core.marshaller.MinimumEscapeHandler;
 import org.glassfish.jaxb.core.marshaller.SAX2DOMEx;
 import org.glassfish.jaxb.core.marshaller.XMLWriter;
@@ -92,6 +94,15 @@ public /*to make unit tests happy*/ final class MarshallerImpl extends AbstractM
 
     /** Object that handles character escaping. */
     private CharacterEscapeHandler escapeHandler = null;
+
+    /**
+     * How to treat characters that are legal in a Java String but illegal in
+     * serialized XML 1.0 (JAXB-614). Defaults from the
+     * {@link InvalidXmlCharacterPolicy#PROPERTY_NAME} system property and is
+     * {@link InvalidXmlCharacterPolicy#WRITE} (historical behaviour) unless
+     * overridden.
+     */
+    private InvalidXmlCharacterPolicy invalidXmlCharacterPolicy = InvalidXmlCharacterPolicy.resolveDefault();
 
     /** XML BLOB written after the XML declaration. */
     private String header=null;
@@ -363,6 +374,13 @@ public /*to make unit tests happy*/ final class MarshallerImpl extends AbstractM
     //
 
     protected CharacterEscapeHandler createEscapeHandler( String encoding ) {
+        // Strip/replace XML-1.0-illegal characters (JAXB-614) on top of whatever
+        // handler is selected below, unless the policy is the historical WRITE.
+        return InvalidXmlCharacterEscapeHandler.wrap(
+                createBaseEscapeHandler(encoding), invalidXmlCharacterPolicy);
+    }
+
+    private CharacterEscapeHandler createBaseEscapeHandler( String encoding ) {
         if( escapeHandler!=null )
             // user-specified one takes precedence.
             return escapeHandler;
@@ -461,8 +479,10 @@ public /*to make unit tests happy*/ final class MarshallerImpl extends AbstractM
             return header;
         if( C14N.equals(name) )
             return c14nSupport;
-        if ( OBJECT_IDENTITY_CYCLE_DETECTION.equals(name)) 
+        if ( OBJECT_IDENTITY_CYCLE_DETECTION.equals(name))
         	return serializer.getObjectIdentityCycleDetection();
+        if ( INVALID_XML_CHARACTER_POLICY.equals(name) )
+            return invalidXmlCharacterPolicy.name();
 
         return super.getProperty(name);
     }
@@ -516,8 +536,27 @@ public /*to make unit tests happy*/ final class MarshallerImpl extends AbstractM
             serializer.setObjectIdentityCycleDetection((Boolean)value);
             return;
         }
+        if ( INVALID_XML_CHARACTER_POLICY.equals(name) ) {
+            invalidXmlCharacterPolicy = toInvalidXmlCharacterPolicy(name, value);
+            return;
+        }
 
         super.setProperty(name, value);
+    }
+
+    /*
+     * Accept either an InvalidXmlCharacterPolicy or its (case-insensitive) name.
+     */
+    private InvalidXmlCharacterPolicy toInvalidXmlCharacterPolicy(String name, Object value) throws PropertyException {
+        if (value instanceof InvalidXmlCharacterPolicy)
+            return (InvalidXmlCharacterPolicy) value;
+        if (value instanceof String)
+            return InvalidXmlCharacterPolicy.parse((String) value);
+        throw new PropertyException(
+                Messages.MUST_BE_X.format(
+                        name,
+                        InvalidXmlCharacterPolicy.class.getName(),
+                        value == null ? "null" : value.getClass().getName()));
     }
 
     /*
@@ -610,4 +649,5 @@ public /*to make unit tests happy*/ final class MarshallerImpl extends AbstractM
     protected static final String XML_HEADERS = "org.glassfish.jaxb.xmlHeaders";
     protected static final String C14N = JAXBRIContext.CANONICALIZATION_SUPPORT;
     protected static final String OBJECT_IDENTITY_CYCLE_DETECTION = "org.glassfish.jaxb.objectIdentitityCycleDetection";
+    protected static final String INVALID_XML_CHARACTER_POLICY = InvalidXmlCharacterPolicy.PROPERTY_NAME;
 }

--- a/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/output/Encoded.java
+++ b/jaxb-ri/runtime/impl/src/main/java/org/glassfish/jaxb/runtime/v2/runtime/output/Encoded.java
@@ -12,6 +12,8 @@ package org.glassfish.jaxb.runtime.v2.runtime.output;
 
 import java.io.IOException;
 
+import org.glassfish.jaxb.core.marshaller.InvalidXmlCharacterPolicy;
+
 /**
  * Buffer for UTF-8 encoded string.
  *
@@ -20,6 +22,17 @@ import java.io.IOException;
  * @author Kohsuke Kawaguchi
  */
 public final class Encoded {
+
+    /**
+     * Policy for characters illegal in serialized XML 1.0 (JAXB-614), applied by
+     * {@link #setEscape}. This is the low-level fallback used when no
+     * {@link org.glassfish.jaxb.core.marshaller.CharacterEscapeHandler} is in
+     * play; the {@link InvalidXmlCharacterPolicy#WRITE} default leaves the hot
+     * path untouched. Resolved once from the system property because this code
+     * path has no access to the per-marshaller configuration.
+     */
+    private static final InvalidXmlCharacterPolicy INVALID_CHAR_POLICY = InvalidXmlCharacterPolicy.resolveDefault();
+
     public byte[] buf;
 
     public int len;
@@ -85,6 +98,18 @@ public final class Encoded {
 
         for (int i = 0; i < length; i++) {
             final char chr = text.charAt(i);
+
+            if (INVALID_CHAR_POLICY != InvalidXmlCharacterPolicy.WRITE
+                    && InvalidXmlCharacterPolicy.isInvalid(chr)) {
+                if (INVALID_CHAR_POLICY == InvalidXmlCharacterPolicy.REPLACE) {
+                    // U+FFFD encodes to the three UTF-8 bytes EF BF BD.
+                    buf[ptr++] = (byte) 0xEF;
+                    buf[ptr++] = (byte) 0xBF;
+                    buf[ptr++] = (byte) 0xBD;
+                }
+                // STRIP: drop the character entirely.
+                continue;
+            }
 
             int ptr1 = ptr;
             if (chr > 0x7F) {

--- a/jaxb-ri/runtime/impl/src/test/java/org/glassfish/jaxb/runtime/unmarshaller/InvalidXmlCharacterMarshalTest.java
+++ b/jaxb-ri/runtime/impl/src/test/java/org/glassfish/jaxb/runtime/unmarshaller/InvalidXmlCharacterMarshalTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package org.glassfish.jaxb.runtime.unmarshaller;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+import org.glassfish.jaxb.core.marshaller.InvalidXmlCharacterPolicy;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Reproduces <a href="https://github.com/eclipse-ee4j/jaxb-ri/issues/614">JAXB-614</a>:
+ * characters legal in a Java String but illegal in XML 1.0 were marshalled
+ * verbatim, producing XML that cannot be parsed back in. Verifies the
+ * {@link InvalidXmlCharacterPolicy} property fixes it.
+ */
+public class InvalidXmlCharacterMarshalTest {
+
+    // A legal value plus stray C0 control characters (ENQ 0x05, ACK 0x06,
+    // UNIT SEPARATOR 0x1f) of the kind seen in the INC7990877 payloads.
+    private static final String DIRTY = "abc\u0005\u0006d\u001fe";
+    private static final String CLEAN = "abcde";
+
+    private Marshaller marshaller(InvalidXmlCharacterPolicy policy) throws Exception {
+        JAXBContext ctx = JAXBContext.newInstance(Bean.class);
+        Marshaller m = ctx.createMarshaller();
+        if (policy != null) {
+            m.setProperty(InvalidXmlCharacterPolicy.PROPERTY_NAME, policy.name());
+        }
+        return m;
+    }
+
+    private Bean newBean() {
+        Bean b = new Bean();
+        b.setElementString(DIRTY);
+        b.setAttributeString(DIRTY);
+        return b;
+    }
+
+    /** Marshal to an OutputStream (UTF-8) — the path api-trips uses for HTTP responses. */
+    private String marshalToUtf8(Marshaller m, Bean bean) throws Exception {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        m.marshal(bean, bos);
+        return bos.toString(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void defaultPolicyReproducesBug() throws Exception {
+        String xml = marshalToUtf8(marshaller(null), newBean());
+        // The illegal bytes are emitted verbatim ...
+        assertTrue(xml.indexOf('\u0005') >= 0, "default WRITE should emit illegal chars verbatim");
+        // ... and the result is not parseable, which is the actual incident symptom.
+        assertThrows(Exception.class, () -> unmarshal(xml));
+    }
+
+    @Test
+    public void stripProducesParseableXmlOnOutputStream() throws Exception {
+        String xml = marshalToUtf8(marshaller(InvalidXmlCharacterPolicy.STRIP), newBean());
+        assertNoControlChars(xml);
+        Bean out = (Bean) unmarshal(xml);
+        assertEquals(CLEAN, out.getElementString());
+        assertEquals(CLEAN, out.getAttributeString());
+    }
+
+    @Test
+    public void stripProducesParseableXmlOnWriter() throws Exception {
+        StringWriter sw = new StringWriter();
+        marshaller(InvalidXmlCharacterPolicy.STRIP).marshal(newBean(), sw);
+        String xml = sw.toString();
+        assertNoControlChars(xml);
+        Bean out = (Bean) unmarshal(xml);
+        assertEquals(CLEAN, out.getElementString());
+        assertEquals(CLEAN, out.getAttributeString());
+    }
+
+    @Test
+    public void replaceSubstitutesReplacementCharacter() throws Exception {
+        String xml = marshalToUtf8(marshaller(InvalidXmlCharacterPolicy.REPLACE), newBean());
+        assertNoControlChars(xml);
+        Bean out = (Bean) unmarshal(xml);
+        // Each of the three illegal chars becomes U+FFFD.
+        assertEquals("abc\uFFFD\uFFFDd\uFFFDe", out.getElementString());
+        assertEquals("abc\uFFFD\uFFFDd\uFFFDe", out.getAttributeString());
+    }
+
+    @Test
+    public void legalControlCharsAreNotStripped() throws Exception {
+        Bean b = new Bean();
+        b.setElementString("line1\nline2\twith tab");
+        String xml = marshalToUtf8(marshaller(InvalidXmlCharacterPolicy.STRIP), b);
+        Bean out = (Bean) unmarshal(xml);
+        // Tab/newline are legal XML chars and must survive (newline round-trips;
+        // we assert the tab and text are intact).
+        assertTrue(out.getElementString().contains("\twith tab"));
+        assertTrue(out.getElementString().contains("line1"));
+        assertTrue(out.getElementString().contains("line2"));
+    }
+
+    private void assertNoControlChars(String xml) {
+        for (int i = 0; i < xml.length(); i++) {
+            assertFalse(InvalidXmlCharacterPolicy.isInvalid(xml.charAt(i)),
+                    "unexpected illegal XML char U+" + Integer.toHexString(xml.charAt(i)) + " at " + i);
+        }
+    }
+
+    private Object unmarshal(String xml) throws Exception {
+        JAXBContext ctx = JAXBContext.newInstance(Bean.class);
+        Unmarshaller u = ctx.createUnmarshaller();
+        return u.unmarshal(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "", propOrder = {"fElementString", "fAttributeString"})
+    @XmlRootElement(name = "Bean")
+    public static class Bean {
+
+        @XmlElement(name = "ElementString")
+        protected String fElementString;
+
+        @XmlAttribute(name = "AttributeString")
+        protected String fAttributeString;
+
+        public String getElementString() {
+            return fElementString;
+        }
+
+        public void setElementString(String elementString) {
+            fElementString = elementString;
+        }
+
+        public String getAttributeString() {
+            return fAttributeString;
+        }
+
+        public void setAttributeString(String attributeString) {
+            fAttributeString = attributeString;
+        }
+    }
+}


### PR DESCRIPTION
  ## Summary
  Fixes #614.

  The JAXB RI marshals characters that are legal in a Java `String` but illegal
  in XML 1.0 (C0 control codes < 0x20 except `\t \n \r`, plus U+FFFE/U+FFFF)
  verbatim. Because XML 1.0 forbids these even as numeric character references,
  the output cannot be parsed back in — marshalling succeeds but unmarshalling
  fails.

  This adds an opt-in policy to strip or replace such characters at emission time.

  ## Changes
  - New `InvalidXmlCharacterPolicy` (`WRITE` / `STRIP` / `REPLACE`) in
    `org.glassfish.jaxb.core.marshaller`.
  - New `InvalidXmlCharacterEscapeHandler` decorator that filters illegal
    characters, then delegates normal escaping to the wrapped handler.
  - Wired into `MarshallerImpl#createEscapeHandler`, covering both the `Writer`
    and `OutputStream`/UTF-8 paths, plus the low-level `Encoded#setEscape`
    fallback.
  - Configurable via the `org.glassfish.jaxb.invalidXmlCharacterPolicy`
    marshaller property or system property of the same name.

  ## Behavior / compatibility
  - **Default is `WRITE`** — existing behavior is unchanged, so this is
    backward-compatible.
  - `STRIP` drops the illegal character; `REPLACE` substitutes U+FFFD.
  - Legal control characters (`\t`, `\n`, `\r`) are never touched.

  ## Tests
  - Added `InvalidXmlCharacterMarshalTest` (5 cases): default reproduces the
    unparseable output; STRIP/REPLACE round-trip on both OutputStream and Writer
    paths; legal control chars are preserved.
  - Full `runtime/impl` suite passes (48 tests, no regressions); `core` tests pass.

  ## Notes for reviewers
  - I deliberately left the default as `WRITE` to avoid changing output for
    existing users; happy to discuss whether a spec-compliant default is
    desirable for a future major version.
  - Scope is the text/UTF-8 marshalling paths. The FastInfoset/StAX output paths
    are not covered here — I can extend if you'd prefer full coverage in this PR.

  A few pointers:
  - Open the PR from a fork against eclipse-ee4j/jaxb-ri:master — contributors don't push branches to the upstream repo.
  - The "Notes for reviewers" section is where this PR earns its keep: flagging the WRITE default and the FastInfoset gap upfront preempts the two most likely review questions.
  - This is an OSS PR on GitHub, so plain markdown — not the ## Summary / ## Test plan checklist style your internal api-trips PRs use.